### PR TITLE
customize block reward for poa

### DIFF
--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -66,10 +66,15 @@ func (w *wizard) makeGenesis() {
 		genesis.Config.Clique = &params.CliqueConfig{
 			Period: 15,
 			Epoch:  30000,
+			Reward: 0,
 		}
 		fmt.Println()
 		fmt.Println("How many seconds should blocks take? (default = 15)")
 		genesis.Config.Clique.Period = uint64(w.readDefaultInt(15))
+
+		fmt.Println()
+		fmt.Println("How many Ethers should be rewarded to signer? (default = 0)")
+		genesis.Config.Clique.Reward = uint64(w.readDefaultInt(0))
 
 		// We also need the initial list of signers
 		fmt.Println()

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -570,6 +570,11 @@ func (c *Clique) Prepare(chain consensus.ChainReader, header *types.Header) erro
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given, and returns the final block.
 func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	// set block reward
+	blockReward := big.NewInt(5e+18)
+	reward := new(big.Int).Set(blockReward)
+	state.AddBalance(header.Coinbase, reward)
+
 	// No block rewards in PoA, so the state remains as is and uncles are dropped
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -571,8 +571,10 @@ func (c *Clique) Prepare(chain consensus.ChainReader, header *types.Header) erro
 // rewards given, and returns the final block.
 func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// set block reward
-	blockReward := big.NewInt(5e+18)
-	reward := new(big.Int).Set(blockReward)
+	// FIXME: unit Ether could be too plump
+	chainReward := new(big.Int).SetUint64(chain.Config().Clique.Reward * params.Ether)
+
+	reward := new(big.Int).Set(chainReward)
 	state.AddBalance(header.Coinbase, reward)
 
 	// No block rewards in PoA, so the state remains as is and uncles are dropped

--- a/params/config.go
+++ b/params/config.go
@@ -135,6 +135,7 @@ func (c *EthashConfig) String() string {
 type CliqueConfig struct {
 	Period uint64 `json:"period"` // Number of seconds between blocks to enforce
 	Epoch  uint64 `json:"epoch"`  // Epoch length to reset votes and checkpoint
+	Reward uint64 `json:"reward"` // Block reward - unit Ether
 }
 
 // String implements the stringer interface, returning the consensus engine details.


### PR DESCRIPTION
This PR aims to give a support for customizing block reward in poa consensus. The option is enabled via genesis configuration. 

Notice - this is an experimental feature.

- [x] add block reward to coinbase
- [x] enable option in genesis