### PR TITLE
fix bug: only cancel mining mode, keep node alive

### DIFF
--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -295,7 +295,8 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		if ok, err := ethereum.ValidateMiner(); err != nil {
 			utils.Fatalf("Can't verify validator permission: %v", err)
 		} else if !ok {
-			utils.Fatalf("Only validator can mine blocks")
+			log.Info("Only validator can mine blocks. Cancel mining on this node")
+			return
 		}
 
 		// Use a reduced number of threads if requested

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -369,10 +369,8 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainReader, header *type
 
 func (c *Clique) GetSnapshot(chain consensus.ChainReader, header *types.Header) (*Snapshot, error) {
 	number := header.Number.Uint64()
-	if number == 0 {
-		return nil, nil
-	}
-	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
+	log.Trace("take snapshot", "number", number, "hash", header.Hash())
+	snap, err := c.snapshot(chain, number, header.Hash(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -339,17 +339,19 @@ func (s *Ethereum) ValidateMiner() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if c, ok := s.engine.(*clique.Clique); !ok {
-		return false, fmt.Errorf("Only verify miners in Clique protocol")
-	} else {
+	if s.chainConfig.Clique != nil {
 		//check if miner's wallet is in set of validators
+		c := s.engine.(*clique.Clique)
 		snap, err := c.GetSnapshot(s.blockchain, s.blockchain.CurrentHeader())
 		if err != nil {
 			return false, fmt.Errorf("Can't verify miner: %v", err)
 		}
 		if _, authorized := snap.Signers[eb]; !authorized {
-			return false, fmt.Errorf("This miner doesn't belong to set of validators")
+			//This miner doesn't belong to set of validators
+			return false, nil
 		}
+	} else {
+		return false, fmt.Errorf("Only verify miners in Clique protocol")
 	}
 	return true, nil
 }


### PR DESCRIPTION
If a full-node isn't started under a validator address, cancelling his mining mode but still keep him alive.