### PR TITLE
allow non-zero coinbase in block header

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -277,9 +277,6 @@ func (c *Clique) verifyHeader(chain consensus.ChainReader, header *types.Header,
 	}
 	// Checkpoint blocks need to enforce zero beneficiary
 	checkpoint := (number % c.config.Epoch) == 0
-	if checkpoint && header.Coinbase != (common.Address{}) {
-		return errInvalidCheckpointBeneficiary
-	}
 	// Nonces must be 0x00..0 or 0xff..f, zeroes enforced on checkpoints
 	if !bytes.Equal(header.Nonce[:], nonceAuthVote) && !bytes.Equal(header.Nonce[:], nonceDropVote) {
 		return errInvalidVote


### PR DESCRIPTION
So we are adjusting poa to support reward. This PR aims to allow non-zero coinbase in block header so that reward can be settle to validator who mines the block.