### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM alpine:latest
 
 LABEL maintainer="etienne@tomochain.com"
 
+WORKDIR /tomochain
+
 COPY --from=builder /tomochain/build/bin/tomo /usr/local/bin/tomo
 
 RUN chmod +x /usr/local/bin/tomo


### PR DESCRIPTION
Add WORKDIR, useful when using the base image to access quick tomo utilities like creating new accounts in a bind-mounted keystore.