### PR TITLE
masternode should also count to his turn in case some of his friends are down

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -48,7 +48,6 @@ const (
 	inmemorySnapshots  = 128                    // Number of recent vote snapshots to keep in memory
 	inmemorySignatures = 4096                   // Number of recent block signatures to keep in memory
 	wiggleTime         = 500 * time.Millisecond // Random delay (per signer) to allow concurrent signers
-
 )
 
 type Masternode struct {
@@ -405,7 +404,9 @@ func (c *Clique) GetMasternodes(chain consensus.ChainReader, header *types.Heade
 	return masternodes
 }
 
-func YourTurn(masternodes []common.Address, snap *Snapshot, header *types.Header, cur common.Address) (bool, error) {
+func (c *Clique) GetPeriod() uint64 { return c.config.Period }
+
+func YourTurn(masternodes []common.Address, snap *Snapshot, header *types.Header, cur common.Address) (int, int, bool, error) {
 	pre := common.Address{}
 	// masternode[0] has chance to create block 1
 	var err error
@@ -413,16 +414,19 @@ func YourTurn(masternodes []common.Address, snap *Snapshot, header *types.Header
 	if header.Number.Uint64() != 0 {
 		pre, err = ecrecover(header, snap.sigcache)
 		if err != nil {
-			return false, err
+			return 0, 0, false, err
 		}
 		preIndex = position(masternodes, pre)
 	}
 	curIndex := position(masternodes, cur)
-	log.Info("Debugging info", "number of masternodes", len(masternodes), "previous", pre, "position", preIndex, "current", cur, "position", curIndex)
+	log.Info("Masternodes cycle info", "number of masternodes", len(masternodes), "previous", pre, "position", preIndex, "current", cur, "position", curIndex)
 	for i, s := range masternodes {
 		fmt.Printf("%d - %s\n", i, s.String())
 	}
-	return (preIndex+1)%len(masternodes) == curIndex, nil
+	if (preIndex+1)%len(masternodes) == curIndex {
+		return preIndex, curIndex, true, nil
+	}
+	return preIndex, curIndex, false, nil
 }
 
 // snapshot retrieves the authorization snapshot at a given point in time.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -49,6 +49,7 @@ var (
 	blockInsertTimer = metrics.NewRegisteredTimer("chain/inserts", nil)
 	CheckpointCh     = make(chan int)
 	M1Ch             = make(chan int)
+	NewBlockCh       = make(chan int)
 	ErrNoGenesis     = errors.New("Genesis not found in chain")
 )
 
@@ -1243,7 +1244,7 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 			context = append(context, []interface{}{"ignored", st.ignored}...)
 		}
 		log.Info("Imported new chain segment", context...)
-
+		NewBlockCh <- 1
 		*st = insertStats{startTime: now, lastIndex: index + 1}
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -49,7 +49,6 @@ var (
 	blockInsertTimer = metrics.NewRegisteredTimer("chain/inserts", nil)
 	CheckpointCh     = make(chan int)
 	M1Ch             = make(chan int)
-	NewBlockCh       = make(chan int)
 	ErrNoGenesis     = errors.New("Genesis not found in chain")
 )
 
@@ -1244,7 +1243,6 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 			context = append(context, []interface{}{"ignored", st.ignored}...)
 		}
 		log.Info("Imported new chain segment", context...)
-		NewBlockCh <- 1
 		*st = insertStats{startTime: now, lastIndex: index + 1}
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -471,8 +471,8 @@ func (s *Ethereum) StartStaking(local bool) error {
 	return nil
 }
 
-func (s *Ethereum) StopStaking()         { s.miner.Stop() }
-func (s *Ethereum) IsStaking() bool      { return s.miner.Mining() }
+func (s *Ethereum) StopStaking()        { s.miner.Stop() }
+func (s *Ethereum) IsStaking() bool     { return s.miner.Mining() }
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 
 func (s *Ethereum) AccountManager() *accounts.Manager  { return s.accountManager }


### PR DESCRIPTION
Definitely we don't want a masternode to wait forever so we add some bits to help him calculate his turn based on parent block - the latest block he get in hand.

fix #77 