### PR TITLE
move gap into genesis config

### DIFF
--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -108,6 +108,10 @@ func (w *wizard) makeGenesis() {
 		genesis.Config.Clique.Epoch = uint64(w.readDefaultInt(990))
 		genesis.Config.Clique.RewardCheckpoint = genesis.Config.Clique.Epoch
 
+		fmt.Println()
+		fmt.Println("How many blocks before checkpoint need to prepare new set of masternodes? (default = 50)")
+		genesis.Config.Clique.Gap = uint64(w.readDefaultInt(50))
+
 	default:
 		log.Crit("Invalid consensus engine choice", "choice", choice)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -62,7 +62,6 @@ const (
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	BlockChainVersion = 3
-	M1Gap             = 5
 )
 
 // CacheConfig contains the configuration values for the trie caching/pruning
@@ -1193,7 +1192,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				CheckpointCh <- 1
 			}
 			// prepare set of masternodes for the next epoch
-			if (chain[i].NumberU64() % bc.chainConfig.Clique.Epoch) == (bc.chainConfig.Clique.Epoch - M1Gap) {
+			if (chain[i].NumberU64() % bc.chainConfig.Clique.Epoch) == (bc.chainConfig.Clique.Epoch - bc.chainConfig.Clique.Gap) {
 				M1Ch <- 1
 			}
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -588,7 +588,7 @@ func (self *worker) commitNewWork() {
 			core.CheckpointCh <- 1
 		}
 		// prepare set of masternodes for the next epoch
-		if (work.Block.NumberU64() % work.config.Clique.Epoch) == (work.config.Clique.Epoch - core.M1Gap) {
+		if (work.Block.NumberU64() % work.config.Clique.Epoch) == (work.config.Clique.Epoch - work.config.Clique.Gap) {
 			core.M1Ch <- 1
 		}
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -137,6 +137,7 @@ type CliqueConfig struct {
 	Epoch            uint64 `json:"epoch"`            // Epoch length to reset votes and checkpoint
 	Reward           uint64 `json:"reward"`           // Block reward - unit Ether
 	RewardCheckpoint uint64 `json:"rewardCheckpoint"` // Checkpoint block for calculate rewards.
+	Gap              uint64 `json:"gap"`              // Gap time preparing for the next epoch
 }
 
 // String implements the stringer interface, returning the consensus engine details.


### PR DESCRIPTION
then it can be easier adjusted per network runs. This gap will also be used to determine when masternodes have to send seed messages.

message 1: checkpoint - gap
message 2: checkpoint - (gap/2)

cc/ @dinhln89 