### PR TITLE
add node docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,46 +53,50 @@ jobs:
         branch: master
         tags: true
 
-  - stage: Build and push tomochain image (untagged)
+  - stage: Build and push latest images
     services:
       - docker
     install: skip
     before_script:
       - docker build -t tomochain/tomochain .
-      - docker run tomochain/tomochain
+      - docker build -t tomochain/node -f Dockerfile.node .
     script:
       - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
       - docker tag tomochain/tomochain tomochain/tomochain:latest
       - docker push tomochain/tomochain:latest
       - docker tag tomochain/tomochain tomochain/tomochain:$TRAVIS_BUILD_ID
       - docker push tomochain/tomochain:$TRAVIS_BUILD_ID
-    after_success:
-      - curl -X POST $INFRA_IMAGE_REBUILD_HOOK
+      - docker tag tomochain/node tomochain/node:latest
+      - docker push tomochain/node:latest
+      - docker tag tomochain/node tomochain/node:$TRAVIS_BUILD_ID
+      - docker push tomochain/node:$TRAVIS_BUILD_ID
 
-  - stage: Build and push tomochain image (tagged)
+  - stage: Build and push tagged images
     services:
       - docker
     install: skip
     before_script:
       - docker build -t tomochain/tomochain .
-      - docker run tomochain/tomochain
+      - docker build -t tomochain/tomochain -f Dockerfile.node .
     script:
       - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
       - docker tag tomochain/tomochain tomochain/tomochain:latest
       - docker push tomochain/tomochain:latest
       - docker tag tomochain/tomochain tomochain/tomochain:$TRAVIS_TAG
       - docker push tomochain/tomochain:$TRAVIS_TAG
-    after_success:
-      - curl -X POST $INFRA_IMAGE_REBUILD_HOOK
+      - docker tag tomochain/tomochain tomochain/node:latest
+      - docker push tomochain/node:latest
+      - docker tag tomochain/node tomochain/node:$TRAVIS_TAG
+      - docker push tomochain/node:$TRAVIS_TAG
 
 stages:
   - name: Lint
   - name: Build and test
   - name: Github release
     if: type != pull_request AND branch =~ ^v AND tag IS present AND repo = tomochain/tomochain
-  - name: Build and push tomochain image (untagged)
+  - name: Build and push latest images
     if: type != pull_request AND branch = master AND tag IS blank AND repo = tomochain/tomochain
-  - name: Build and push tomochain image (tagged)
+  - name: Build and push tagged images
     if: type != pull_request AND branch =~ ^v AND tag IS present AND repo = tomochain/tomochain
 
 notifications:

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,37 @@
+FROM golang:1.10-alpine as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers
+
+ADD . /tomochain
+
+RUN cd /tomochain \
+    && make tomo \
+    && chmod +x /tomochain/build/bin/tomo
+
+FROM alpine:latest
+
+LABEL maintainer="etienne@tomochain.com"
+
+WORKDIR /tomochain
+
+COPY --from=builder /tomochain/build/bin/tomo /usr/local/bin/tomo
+
+ENV IDENTITY ''
+ENV PASSWORD ''
+ENV PRIVATE_KEY ''
+ENV BOOTNODES ''
+ENV EXTIP ''
+ENV SYNC_MODE 'full'
+ENV NETWORK_ID '89'
+ENV WS_SECRET ''
+ENV NETSTATS_HOST 'netstats-server'
+ENV NETSTATS_PORT '3000'
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker/tomochain ./
+COPY genesis/ ./
+
+EXPOSE 8545 8546 30303 30303/udp
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -1,0 +1,162 @@
+#!/bin/sh -x
+
+# vars from docker env
+# - IDENTITY (default to empty)
+# - PASSWORD (default to empty)
+# - PRIVATE_KEY (default to empty)
+# - BOOTNODES (default to empty)
+# - EXTIP (default to empty)
+# - SYNC_MODE (default to 'full')
+# - NETWORK_ID (default to '89')
+# - WS_SECRET (default to empty)
+# - NETSTATS_HOST (default to 'netstats-server:3000')
+# - NETSTATS_PORT (default to 'netstats-server:3000')
+
+# constants
+DATA_DIR="data"
+KEYSTORE_DIR="keystore"
+
+# variables
+genesisPath=""
+params=""
+accountsCount=$(
+  tomo account list --datadir $DATA_DIR  --keystore $KEYSTORE_DIR \
+  2> /dev/null \
+  | wc -l
+)
+
+# file to env
+for env in IDENTITY PASSWORD PRIVATE_KEY BOOTNODES WS_SECRET NETSTATS_HOST \
+           NETSTATS_PORT EXTIP SYNC_MODE NETWORK_ID; do
+  file=$(eval echo "\$${env}_FILE")
+  if [[ -f $file ]] && [[ ! -z $file ]]; then
+    echo "Replacing $env by $file"
+    export $env=$(cat $file)
+  elif [[ "$env" == "BOOTNODES" ]] && [[ ! -z $file ]]; then
+    echo "Bootnodes file is not available. Waiting for it to be provisioned..."
+    while true ; do
+      if [[ -f $file ]] && [[ $(grep -e enode $file) ]]; then
+        echo "Fount bootnode file."
+        break
+      fi
+      echo "Still no bootnodes file, sleeping..."
+      sleep 5
+    done
+    export $env=$(cat $file)
+  fi
+done
+
+# networkid
+if [[ ! -z $NETWORK_ID ]]; then
+  case $NETWORK_ID in
+    88 )
+      genesisPath="mainnet.json"
+      ;;
+    89 )
+      genesisPath="testnet.json"
+      ;;
+    90 )
+      genesisPath="devnet.json"
+      ;;
+    * )
+      echo "network id not supported"
+      ;;
+  esac
+  params="$params --networkid $NETWORK_ID"
+fi
+
+# data dir
+if [[ ! -d $DATA_DIR/tomo ]]; then
+  echo "No blockchain data, creating genesis block."
+  tomo init $genesisPath --datadir $DATA_DIR 2> /dev/null
+fi
+
+# identity
+if [[ -z $IDENTITY ]]; then
+  IDENTITY="unnamed_$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)"
+fi
+
+# password file
+if [[ ! -f ./password ]]; then
+  if [[ ! -z $PASSWORD ]]; then
+    echo "Password env is set. Writing into file."
+    echo "$PASSWORD" > ./password
+  else
+    echo "No password set (or empty), generating a new one"
+    $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32} > password)
+  fi
+fi
+
+# private key
+if [[ $accountsCount -le 0 ]]; then
+  echo "No accounts found"
+  if [[ ! -z $PRIVATE_KEY ]]; then
+    echo "Creating account from private key"
+    echo "$PRIVATE_KEY" > ./private_key
+    tomo  account import ./private_key \
+      --datadir $DATA_DIR \
+      --keystore $KEYSTORE_DIR \
+      --password ./password
+  else
+    echo "Creating new account"
+    tomo account new \
+      --datadir $DATA_DIR \
+      --keystore $KEYSTORE_DIR \
+      --password ./password
+  fi
+fi
+account=$(
+  tomo account list --datadir $DATA_DIR  --keystore $KEYSTORE_DIR \
+  2> /dev/null \
+  | head -n 1 \
+  | cut -d"{" -f 2 | cut -d"}" -f 1
+)
+echo "Using account $account"
+params="$params --unlock $account"
+
+# bootnodes
+if [[ ! -z $BOOTNODES ]]; then
+  params="$params --bootnodes $BOOTNODES"
+fi
+
+# extip
+if [[ ! -z $EXTIP ]]; then
+  params="$params --nat extip:${EXTIP}"
+fi
+
+# syncmode
+if [[ ! -z $SYNC_MODE ]]; then
+  params="$params --syncmode ${SYNC_MODE}"
+fi
+
+# netstats
+if [[ ! -z $WS_SECRET ]]; then
+  echo "Will report to netstats server ${NETSTATS_HOST}:${NETSTATS_PORT}"
+  params="$params --ethstats ${IDENTITY}:${WS_SECRET}@${NETSTATS_HOST}:${NETSTATS_PORT}"
+else
+  echo "WS_SECRET not set, will not report to netstats server."
+fi
+
+# dump
+echo "dump: $IDENTITY $account $BOOTNODES"
+
+exec tomo $params \
+  --verbosity 4 \
+  --datadir $DATA_DIR \
+  --keystore $KEYSTORE_DIR \
+  --identity $IDENTITY \
+  --password ./password \
+  --port 30303 \
+  --rpc \
+  --rpccorsdomain "*" \
+  --rpcaddr 0.0.0.0 \
+  --rpcport 8545 \
+  --rpcvhosts "*" \
+  --ws \
+  --wsaddr 0.0.0.0 \
+  --wsport 8546 \
+  --wsorigins "*" \
+  --mine \
+  --gasprice "1" \
+  --targetgaslimit "420000000" \
+  "$@"


### PR DESCRIPTION
So here's the solution I came up with.
The goal is to not have an infra-image who reside on another repo.
I tried to use only one image but it makes it really complicated for someone who want to use the binary for other use than running a node (for ex, the js console https://github.com/tomochain/tomochain#attach-to-the-tomochain-test-network ) to use the docker image.
So instead, I propose to add a new docker image, tomochain/node. Who reside in this repository and container all the logic to run a node.

We still have two images, but one doesn't rely on the other. You can run each of them independently. and are built at the same time.

Some improvements in node image compared to infra-tomochain image:
- can set network id (default to testnet 89)
- dynamically chose genesis depending on the network id
- can set node type (default to full)