### PR TITLE
Remove pkey file from node container after importing the account

### DIFF
--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -98,6 +98,7 @@ if [[ $accountsCount -le 0 ]]; then
       --datadir $DATA_DIR \
       --keystore $KEYSTORE_DIR \
       --password ./password
+    rm ./private_key
   else
     echo "Creating new account"
     tomo account new \


### PR DESCRIPTION
Close #193 , the entrypoint now remove the pkey after importing the account