### PR TITLE
remove bash debug from docker entrypoint

### DIFF
--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -142,6 +142,8 @@ fi
 # dump
 echo "dump: $IDENTITY $account $BOOTNODES"
 
+set -x
+
 exec tomo $params \
   --verbosity $VERBOSITY \
   --datadir $DATA_DIR \

--- a/docker/tomochain/entrypoint.sh
+++ b/docker/tomochain/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # vars from docker env
 # - IDENTITY (default to empty)


### PR DESCRIPTION
Not needed anymore as we had not problem with it.
Also, more secure as no pkey will end up in the logs