### PR TITLE
double validation bugfix 

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -191,7 +191,8 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 
 		// Hook double validation
 		doubleValidateHook := func(block *types.Block) error {
-			snap, err := c.GetSnapshot(eth.blockchain, block.Header())
+			parentBlk := eth.blockchain.GetBlockByHash(block.ParentHash())
+			snap, err := c.GetSnapshot(eth.blockchain, parentBlk.Header())
 			if err != nil {
 				if err == consensus.ErrUnknownAncestor {
 					log.Warn("Block chain forked.", "error", err)


### PR DESCRIPTION
```
ERROR[10-23|08:39:40] Double validation failed                 err="Fail to get snapshot for sign tx validator: unknown ancestor" Discard this block!=nil LOG15_ERROR="Normalized odd number of arguments by adding nil"
```

get snapshot from parent of the importing block fixes this.