### PR TITLE
fix error panic in func RemoveItemFromArray

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -249,11 +249,19 @@ func RemoveItemFromArray(array []Address, items []Address) []Address {
 	if items == nil {
 		return array
 	}
-	for i, value := range array {
+	i := 0;
+	for i < len(array) {
+		value := array[i]
+		remove := false
 		for _, item := range items {
 			if value == item {
 				array = append(array[:i], array[i+1:]...)
+				remove = true
+				break
 			}
+		}
+		if !remove {
+			i++
 		}
 	}
 	return array

--- a/common/types.go
+++ b/common/types.go
@@ -246,24 +246,18 @@ func (a UnprefixedAddress) MarshalText() ([]byte, error) {
 
 // Extract validators from byte array.
 func RemoveItemFromArray(array []Address, items []Address) []Address {
-	if items == nil {
+	if len(items) == 0 {
 		return array
 	}
-	i := 0;
-	for i < len(array) {
-		value := array[i]
-		remove := false
-		for _, item := range items {
-			if value == item {
+
+	for _, item := range items {
+		for i := len(array) - 1; i >= 0; i-- {
+			if array[i] == item {
 				array = append(array[:i], array[i+1:]...)
-				remove = true
-				break
 			}
 		}
-		if !remove {
-			i++
-		}
 	}
+
 	return array
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -151,10 +151,10 @@ func BenchmarkAddressHex(b *testing.B) {
 }
 
 func TestRemoveItemInArray(t *testing.T) {
-	array := []Address{HexToAddress("0x0000000"), HexToAddress("0x0000001"), HexToAddress("0x0000002")}
-	remove := []Address{HexToAddress("0x0000000"), HexToAddress("0x0000004"), HexToAddress("0x0000003")}
+	array := []Address{HexToAddress("0x0000003"),HexToAddress("0x0000001"), HexToAddress("0x0000002"),HexToAddress("0x0000003")}
+	remove := []Address{HexToAddress("0x0000002"), HexToAddress("0x0000004"), HexToAddress("0x0000003")}
 	array = RemoveItemFromArray(array, remove)
-	if len(array) != 2 {
+	if len(array) != 1 {
 		t.Error("fail remove item from array address")
 	}
 }


### PR DESCRIPTION
panic: runtime error: slice bounds out of range
goroutine 100 [running]:
github.com/ethereum/go-ethereum/common.RemoveItemFromArray(0xc0055e1b20, 0x5, 0x5, 0xc0055e1b90, 0x5, 0x5, 0x0, 0x0, 0x0)