### PR TITLE
fix error fatal error: concurrent map read and map write

### DIFF
--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -669,7 +669,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 				go f.broadcastBlock(block, true)
 				return
 			}
-			f.enqueue(peer, newBlock)
+			f.Enqueue(peer, newBlock)
 			return
 		default:
 			// Something went very wrong, drop the peer


### PR DESCRIPTION
Detail error in line code 
`if _, ok := f.queued[hash]; !ok {`

fatal error: concurrent map read and map write

goroutine 117 [running]:
runtime.throw(0xfcdc9e, 0x21)
        /usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc018864980 sp=0xc018864950 pc=0x441d72
runtime.mapaccess1_faststr(0xe33640, 0xc00001ac90, 0xc000494bc0, 0x10, 0xb234eadab1c2be45)
        /usr/local/go/src/runtime/map_faststr.go:21 +0x418 fp=0xc0188649f0 sp=0xc018864980 pc=0x427958
github.com/ethereum/go-ethereum/eth/fetcher.(*Fetcher).enqueue(0xc0003de2a0, 0xc000494bc0, 0x10, 0xc029b44ea0)
        /home/tamnb/_projects/tomochain/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/fetcher/fetcher.go:606 +0x98 fp=0xc018864d70 sp=0xc0188649f0 pc=0xb00638
github.com/ethereum/go-ethereum/eth/fetcher.(*Fetcher).loop(0xc0003de2a0)
        /home/tamnb/_projects/tomochain/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/fetcher/fetcher.go:359 +0x361a fp=0xc018865fd8 sp=0xc018864d70 pc=0xaff9ba
