### PR TITLE
Critical log if failed count signers

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -313,7 +313,8 @@ func GetRewardForCheckpoint(chain consensus.ChainReader, blockSignerAddr common.
 			block := chain.GetHeaderByNumber(i)
 			addrs, err := GetSignersFromContract(blockSignerAddr, client, block.Hash())
 			if err != nil {
-				log.Crit("Fail to get signers from smartcontract.", "error", err, "blockNumber", i)
+				log.Error("Fail to get signers from smartcontract.", "error", err, "blockNumber", i)
+				return nil, err
 			}
 			// Filter duplicate address.
 			if len(addrs) > 0 {
@@ -410,7 +411,8 @@ func GetRewardBalancesRate(foudationWalletAddr common.Address, masterAddr common
 	opts := new(bind.CallOpts)
 	voters, err := validator.GetVoters(opts, masterAddr)
 	if err != nil {
-		log.Crit("Fail to get voters", "error", err)
+		log.Error("Fail to get voters", "error", err)
+		return nil, err
 	}
 
 	if len(voters) > 0 {
@@ -422,7 +424,8 @@ func GetRewardBalancesRate(foudationWalletAddr common.Address, masterAddr common
 		for _, voteAddr := range voters {
 			voterCap, err := validator.GetVoterCap(opts, masterAddr, voteAddr)
 			if err != nil {
-				log.Crit("Fail to get vote capacity", "error", err)
+				log.Error("Fail to get vote capacity", "error", err)
+				return nil, err
 			}
 
 			totalCap.Add(totalCap, voterCap)

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -313,8 +313,7 @@ func GetRewardForCheckpoint(chain consensus.ChainReader, blockSignerAddr common.
 			block := chain.GetHeaderByNumber(i)
 			addrs, err := GetSignersFromContract(blockSignerAddr, client, block.Hash())
 			if err != nil {
-				log.Error("Fail to get signers from smartcontract.", "error", err, "blockNumber", i)
-				return nil, err
+				log.Crit("Fail to get signers from smartcontract.", "error", err, "blockNumber", i)
 			}
 			// Filter duplicate address.
 			if len(addrs) > 0 {

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -410,8 +410,7 @@ func GetRewardBalancesRate(foudationWalletAddr common.Address, masterAddr common
 	opts := new(bind.CallOpts)
 	voters, err := validator.GetVoters(opts, masterAddr)
 	if err != nil {
-		log.Error("Fail to get voters", "error", err)
-		return nil, err
+		log.Crit("Fail to get voters", "error", err)
 	}
 
 	if len(voters) > 0 {
@@ -423,8 +422,7 @@ func GetRewardBalancesRate(foudationWalletAddr common.Address, masterAddr common
 		for _, voteAddr := range voters {
 			voterCap, err := validator.GetVoterCap(opts, masterAddr, voteAddr)
 			if err != nil {
-				log.Error("Fail to get vote capacity", "error", err)
-				return nil, err
+				log.Crit("Fail to get vote capacity", "error", err)
 			}
 
 			totalCap.Add(totalCap, voterCap)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -292,8 +292,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		c.HookReward = func(chain consensus.ChainReader, state *state.StateDB, header *types.Header) (error, map[string]interface{}) {
 			client, err := eth.blockchain.GetClient()
 			if err != nil {
-				log.Error("Fail to connect IPC client for blockSigner", "error", err)
-				return err, nil
+				log.Crit("Fail to connect IPC client for blockSigner", "error", err)
 			}
 			number := header.Number.Uint64()
 			rCheckpoint := chain.Config().Posv.RewardCheckpoint
@@ -313,20 +312,17 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 				totalSigner := new(uint64)
 				signers, err := contracts.GetRewardForCheckpoint(chain, addr, number, rCheckpoint, client, totalSigner)
 				if err != nil {
-					log.Error("Fail to get signers for reward checkpoint", "error", err)
-					return err, nil
+					log.Crit("Fail to get signers for reward checkpoint", "error", err)
 				}
 				rewards["signers"] = signers
 				rewardSigners, err := contracts.CalculateRewardForSigner(chainReward, signers, *totalSigner)
 				if err != nil {
-					log.Error("Fail to calculate reward for signers", "error", err)
-					return err, nil
+					log.Crit("Fail to calculate reward for signers", "error", err)
 				}
 				// Get validator.
 				validator, err := contract.NewTomoValidator(common.HexToAddress(common.MasternodeVotingSMC), client)
 				if err != nil {
-					log.Error("Fail get instance of Tomo Validator", "error", err)
-					return err, nil
+					log.Crit("Fail get instance of Tomo Validator", "error", err)
 				}
 				// Add reward for coin holders.
 				voterResults := make(map[common.Address]interface{})
@@ -334,8 +330,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 					for signer, calcReward := range rewardSigners {
 						err, rewards := contracts.CalculateRewardForHolders(foudationWalletAddr, validator, state, signer, calcReward)
 						if err != nil {
-							log.Error("Fail to calculate reward for holders.", "error", err)
-							return err, nil
+							log.Crit("Fail to calculate reward for holders.", "error", err)
 						}
 						voterResults[signer] = rewards
 					}


### PR DESCRIPTION
To fix the fork issue when calculate reward is failed
```
ERROR[12-31|10:11:50] Fail to get signers from smartcontract.  error="abi: unmarshalling empty output" blockNumber=623130
```

```
ERROR[12-31|20:25:51] Fail to get vote capacity error="abi: unmarshalling empty output"
```

```
Error: invalid merkle root (remote: 1ff10108851317a6d6f2fcaa98e0d31c6640ce42ed267d923cf9cce86b8afab9 local: 606b684d9f82d7b2e519cf380c308d392aacb67f7230d614236e358d3a74d853)
```