### PR TITLE
Update orderlistkey prefix

### DIFF
--- a/tomox/orderlist.go
+++ b/tomox/orderlist.go
@@ -342,6 +342,6 @@ func (orderList *OrderList) Hash() (common.Hash, error) {
 	return common.BytesToHash(olEncoded), nil
 }
 
-func (orderList *OrderList) GetCommonKey() []byte {
-	return append([]byte("OL"), orderList.Key...)
+func GetOrderListCommonKey(key []byte) []byte {
+	return append([]byte("OL"), key...)
 }

--- a/tomox/ordertree.go
+++ b/tomox/ordertree.go
@@ -144,6 +144,8 @@ func (orderTree *OrderTree) getKeyFromPrice(price *big.Int) []byte {
 func (orderTree *OrderTree) PriceList(price *big.Int) *OrderList {
 
 	key := orderTree.getKeyFromPrice(price)
+	// append orderlistKey prefix
+	key = append([]byte("OL"), key...)
 	bytes, found := orderTree.PriceTree.Get(key)
 	log.Debug("Got orderlist by price", "key", hex.EncodeToString(key), "found", found)
 
@@ -192,6 +194,8 @@ func (orderTree *OrderTree) Depth() uint64 {
 func (orderTree *OrderTree) RemovePrice(price *big.Int) error {
 	if orderTree.Depth() > 0 {
 		orderListKey := orderTree.getKeyFromPrice(price)
+		// append orderlistKey prefix
+		orderListKey = append([]byte("OL"), orderListKey...)
 		orderTree.PriceTree.Remove(orderListKey)
 
 		// should use batch to optimize the performance
@@ -206,7 +210,8 @@ func (orderTree *OrderTree) RemovePrice(price *big.Int) error {
 func (orderTree *OrderTree) PriceExist(price *big.Int) bool {
 
 	orderListKey := orderTree.getKeyFromPrice(price)
-
+	// append orderlistKey prefix
+	orderListKey = append([]byte("OL"), orderListKey...)
 	found, _ := orderTree.PriceTree.Has(orderListKey)
 
 	return found

--- a/tomox/snapshot_test.go
+++ b/tomox/snapshot_test.go
@@ -188,19 +188,15 @@ func TestTomoX_Snapshot(t *testing.T) {
 	// delete some orders from database
 	// we expect that snapshot loading process should put them back
 	// remove order whose OrderId = 1 (bid order)
-	key := GetKeyFromBig(new(big.Int).SetUint64(1))
 	price := CloneBigInt(ether)
 	price = price.Mul(price, big.NewInt(99))
-	ol := ob.Bids.PriceList(price)
-	if err = ob.Bids.orderDB.Delete(common.BigToHash(Add(ol.slot, new(big.Int).SetBytes(key))).Bytes(), true); err != nil {
+	if err = ob.Bids.orderDB.Delete(ob.Bids.getKeyFromPrice(price), true); err != nil {
 		t.Error("Failed to delete order", "price", price)
 	}
 	// remove order whose OrderId = 4 (ask order)
-	key = GetKeyFromBig(new(big.Int).SetUint64(4))
 	price = CloneBigInt(ether)
 	price = price.Mul(price, big.NewInt(102))
-	ol = ob.Asks.PriceList(price)
-	if err = ob.Asks.orderDB.Delete(common.BigToHash(Add(ol.slot, new(big.Int).SetBytes(key))).Bytes(), true); err != nil {
+	if err = ob.Asks.orderDB.Delete(ob.Asks.getKeyFromPrice(price), true); err != nil {
 		t.Error("Failed to delete order", "price", price)
 	}
 


### PR DESCRIPTION
This should resolve https://github.com/tomochain/tomochain/issues/558 
Root cause: mismatch orderList keys in 
- createPrice: have prefix "OL"
https://github.com/tomochain/tomochain/blob/tomoX/tomox/ordertree.go#L184
- RemovePrice: without any prefix
https://github.com/tomochain/tomochain/blob/tomoX/tomox/ordertree.go#L195
- PriceList: without any prefix
https://github.com/tomochain/tomochain/blob/tomoX/tomox/ordertree.go#L147

It causes that orderList cannot be removed from orderTree, even its length is zero, then orderTree is never empty
--> infinite loop here
https://github.com/tomochain/tomochain/blob/tomoX/tomox/orderbook.go#L267