### PR TITLE
tomox snapshot follow up

### DIFF
--- a/tomox/iterator.go
+++ b/tomox/iterator.go
@@ -38,16 +38,25 @@ func (iterator *Iterator) Next() bool {
 		iterator.node = left
 		goto between
 	}
-	if iterator.node.Item.Keys.Right != nil {
+	if len(iterator.node.Item.Keys.Right) > 0 {
 		iterator.node = iterator.node.Right(iterator.tree)
-		for iterator.node.Item.Keys.Left != nil {
+		if iterator.node == nil {
+			goto end
+		}
+		for len(iterator.node.Item.Keys.Left) > 0 {
 			iterator.node = iterator.node.Left(iterator.tree)
+			if iterator.node == nil {
+				goto end
+			}
 		}
 		goto between
 	}
-	if iterator.node.Item.Keys.Parent != nil {
+	if len(iterator.node.Item.Keys.Parent) > 0 {
 		node := iterator.node
-		for iterator.node.Item.Keys.Parent != nil {
+		for len(iterator.node.Item.Keys.Parent) > 0 {
+			if iterator.node == nil {
+				goto end
+			}
 			iterator.node = iterator.node.Parent(iterator.tree)
 			if iterator.tree.Comparator(node.Key, iterator.node.Key) <= 0 {
 				goto between

--- a/tomox/snapshot.go
+++ b/tomox/snapshot.go
@@ -122,8 +122,8 @@ func prepareOrderTreeData(tree *OrderTree) (*OrderTreeSnapshot, error) {
 				items    [][]byte
 				byteItem []byte
 			)
-			for ol != nil && ol.Item != nil && ol.Item.Length > 0 {
-				headOrder := ol.GetOrder(ol.Item.HeadOrder)
+			headOrder := ol.GetOrder(ol.Item.HeadOrder)
+			for headOrder != nil {
 				if byteItem, err = EncodeBytesItem(headOrder.Item); err != nil {
 					return nil, err
 				}
@@ -131,6 +131,7 @@ func prepareOrderTreeData(tree *OrderTree) (*OrderTreeSnapshot, error) {
 				if err = ol.RemoveOrder(headOrder); err != nil {
 					return nil, err
 				}
+				headOrder = ol.GetOrder(ol.Item.HeadOrder)
 			}
 
 			snap.OrderList[priceKeyHash] = &OrderListSnapshot{

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -903,7 +903,7 @@ func (tomox *TomoX) getOrderPending(orderHash common.Hash) *OrderItem {
 	prefix := []byte(pendingPrefix)
 	key := append(prefix, orderHash.Bytes()...)
 	if ok, _ := tomox.db.Has(key); ok {
-		val, err = tomox.db.Get(key, val)
+		val, err = tomox.db.Get(key, &OrderItem{})
 		if err != nil {
 			log.Error("Fail to get order pending", "err", err)
 
@@ -958,7 +958,7 @@ func (tomox *TomoX) addPendingHash(orderHash common.Hash) error {
 	}
 	// Store pending hash.
 	key := []byte(pendingHash)
-	if err := tomox.db.Put(key, pendingHashes); err != nil {
+	if err := tomox.db.Put(key, &pendingHashes); err != nil {
 		log.Error("Fail to save order hash pending", "err", err)
 		return err
 	}
@@ -978,7 +978,7 @@ func (tomox *TomoX) removePendingHash(orderHash common.Hash) error {
 		}
 	}
 	// Store pending hash.
-	if err := tomox.db.Put([]byte(pendingHash), pendingHashes); err != nil {
+	if err := tomox.db.Put([]byte(pendingHash), &pendingHashes); err != nil {
 		log.Error("Fail to delete order hash pending", "err", err)
 		return err
 	}
@@ -993,7 +993,7 @@ func (tomox *TomoX) getPendingHashes() []common.Hash {
 	)
 	key := []byte(pendingHash)
 	if ok, _ := tomox.db.Has(key); ok {
-		if val, err = tomox.db.Get(key, val); err != nil {
+		if val, err = tomox.db.Get(key, &[]common.Hash{}); err != nil {
 			log.Error("Fail to get pending hash", "err", err)
 			return []common.Hash{}
 		}
@@ -1002,7 +1002,7 @@ func (tomox *TomoX) getPendingHashes() []common.Hash {
 	if val == nil {
 		return []common.Hash{}
 	}
-	pendingHashes := val.([]common.Hash)
+	pendingHashes := *val.(*[]common.Hash)
 
 	return pendingHashes
 }
@@ -1017,7 +1017,7 @@ func (tomox *TomoX) addProcessedOrderHash(orderHash common.Hash, limit int) erro
 	}
 	processedHashes = append(processedHashes, orderHash)
 
-	if err := tomox.db.Put(key, processedHashes); err != nil {
+	if err := tomox.db.Put(key, &processedHashes); err != nil {
 		log.Error("Fail to save processed order hashes", "err", err)
 		return err
 	}
@@ -1031,7 +1031,6 @@ func (tomox *TomoX) existProcessedOrderHash(orderHash common.Hash) bool {
 	for _, k := range processedHashes {
 		if k == orderHash {
 			return true
-			break
 		}
 	}
 
@@ -1046,7 +1045,7 @@ func (tomox *TomoX) getProcessedOrderHash() []common.Hash {
 
 	key := []byte(processedHash)
 	if ok, _ := tomox.db.Has(key); ok {
-		if val, err = tomox.db.Get(key, val); err != nil {
+		if val, err = tomox.db.Get(key, &[]common.Hash{}); err != nil {
 			log.Error("Failed to load processed order hashes", "err", err)
 			return nil
 		}
@@ -1054,7 +1053,7 @@ func (tomox *TomoX) getProcessedOrderHash() []common.Hash {
 
 	var processedHashes []common.Hash
 	if val != nil {
-		processedHashes = val.([]common.Hash)
+		processedHashes = *val.(*[]common.Hash)
 	}
 
 	return processedHashes

--- a/tomox/tomox_test.go
+++ b/tomox/tomox_test.go
@@ -140,6 +140,7 @@ func TestDBPending(t *testing.T) {
 	tomox.addPendingHash(hash)
 	hash = common.StringToHash("0x0000000000000000000000000000000000000002")
 	tomox.addPendingHash(hash)
+	// getPendingHashes from cache
 	if pHashes := tomox.getPendingHashes(); len(pHashes) != 3 {
 		t.Error("Expected: 3 pending hash", "Actual:", len(pHashes))
 	}
@@ -147,6 +148,10 @@ func TestDBPending(t *testing.T) {
 	// Test remove hash
 	hash = common.StringToHash("0x0000000000000000000000000000000000000002")
 	tomox.removePendingHash(hash)
+	// commit to force getPendingHashes from db
+	if err := tomox.db.Commit(); err != nil {
+		t.Error(err)
+	}
 	if pHashes := tomox.getPendingHashes(); len(pHashes) != 2 {
 		t.Error("Expected: 2 pending hash", "Actual:", len(pHashes))
 	}
@@ -297,6 +302,10 @@ func TestProcessedHash(t *testing.T) {
 	pHashes := tomox.getProcessedOrderHash()
 	if len(pHashes) != 3 {
 		t.Error("Expected: 3 processed hash", "Actual:", len(pHashes), "pHashes", pHashes)
+	}
+	// commit to force checking existProcessedOrderHash from db
+	if err := tomox.db.Commit(); err != nil {
+		t.Error(err)
 	}
 	if !tomox.existProcessedOrderHash(common.StringToHash("0x0000000000000000000000000000000000000004")) {
 		t.Error("Processed hash not exist")

--- a/tomox/tomox_test.go
+++ b/tomox/tomox_test.go
@@ -26,7 +26,7 @@ func buildOrder(nonce *big.Int) *OrderItem {
 		QuoteToken:      common.StringToAddress("0x9a8531c62d02af08cf237eb8aecae9dbcb69b6fd"),
 		Status:          "New",
 		Side:            lstBuySell[rand.Int()%len(lstBuySell)],
-		Type:            "LO",
+		Type:            Limit,
 		PairName:        "0x9a8531c62d02af08cf237eb8aecae9dbcb69b6fd" + "::" + "0x9a8531c62d02af08cf237eb8aecae9dbcb69b6fd",
 		//Hash:            common.StringToHash("0xdc842ea4a239d1a4e56f1e7ba31aab5a307cb643a9f5b89f972f2f5f0d1e7587"),
 		Hash: common.StringToHash(nonce.String()),
@@ -246,8 +246,8 @@ func TestEncodeDecodeTXMatch(t *testing.T) {
 	}
 	txMatches = make(map[common.Hash]TxDataMatch)
 	txMatches[order.Hash] = TxDataMatch{
-		order:  value,
-		trades: trades,
+		Order:  value,
+		Trades: trades,
 	}
 	encode, err := json.Marshal(txMatches)
 	if err != nil {


### PR DESCRIPTION
follow up of https://github.com/tomochain/tomochain/pull/539
Testing scenario: (5 masternodes)
- Place a few Bid, Ask orders
- Check log to see if Snapshot is stored successfully, check blockhash at snapshot point,  BidTree size, askTree size
- Stop a node 
- Restart node
- Check log to see if Snapshot is loaded successfully, verify blockhash of snapshot,  BidTree size, askTree size

```go
DEBUG[07-12|14:45:34] Snapshot process takes                   time=6.190ms     hash=ba3f31…f2a4d3
DEBUG[07-12|14:45:44] Snapshot process takes                   time=5.834ms     hash=4dfdcf…55d840
tail: local_tomo/node1/log.out: file truncated
DEBUG[07-12|14:45:48] Successfully load snapshot               time=8.957ms hash=4dfdcf…55d840
DEBUG[07-12|14:46:05] Snapshot process takes                   time=14.024ms  hash=c47295…f7b197
```