### PR TITLE
Revert "Concurrent read/write during contract deployment"

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -346,11 +346,7 @@ func (self *worker) wait() {
 			for _, log := range work.state.Logs() {
 				log.BlockHash = block.Hash()
 			}
-			
-                        self.currentMu.Lock()
 			stat, err := self.chain.WriteBlockWithState(block, work.receipts, work.state)
-                        self.currentMu.Unlock()
-			
 			if err != nil {
 				log.Error("Failed writing block to chain", "err", err)
 				continue


### PR DESCRIPTION
Reverts tomochain/tomochain#567

Inner func already has lock