### PR TITLE
Sdk nodes ignore matching engine

### DIFF
--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -50,10 +50,10 @@ func NewMongoDatabase(session *mgo.Session, mongoURL string, cacheLimit int) (*M
 	dryRunCache, _ := lru.New(itemCacheLimit)
 
 	db := &MongoDatabase{
-		Session:        session,
-		dbName:         dbName,
-		cacheItems:     cacheItems,
-		dryRunCache:    dryRunCache,
+		Session:     session,
+		dbName:      dbName,
+		cacheItems:  cacheItems,
+		dryRunCache: dryRunCache,
 	}
 
 	return db, nil
@@ -131,7 +131,6 @@ func (db *MongoDatabase) Get(key []byte, val interface{}, dryrun bool) (interfac
 			return value, nil
 		}
 	}
-
 	if cached, ok := db.cacheItems.Get(cacheKey); ok && !dryrun {
 		return cached, nil
 	} else {
@@ -173,7 +172,7 @@ func (db *MongoDatabase) Put(key []byte, val interface{}, dryrun bool) error {
 		return nil
 	}
 
-	log.Debug("Debug DB put", "cacheKey", cacheKey,  "val", val)
+	log.Debug("Debug DB put", "cacheKey", cacheKey, "val", val)
 	db.cacheItems.Add(cacheKey, val)
 
 	switch val.(type) {
@@ -241,14 +240,13 @@ func (db *MongoDatabase) Delete(key []byte, dryrun bool) error {
 }
 
 func (db *MongoDatabase) InitDryRunMode() {
-	log.Debug("Start dry-run mode, clear old data")
-	db.dryRunCache.Purge()
+	// SDK node (which running with mongodb) doesn't run Matching engine
+	// dry-run cache is useless for sdk node
 }
 
 func (db *MongoDatabase) SaveDryRunResult() error {
 	// SDK node (which running with mongodb) doesn't run Matching engine
 	// dry-run cache is useless for sdk node
-	db.dryRunCache.Purge()
 	return nil
 }
 

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -3,15 +3,13 @@ package tomox
 import (
 	"bytes"
 	"encoding/hex"
-	"time"
-	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
-	"github.com/tomochain/tomox-sdk/types"
 	"github.com/hashicorp/golang-lru"
+	"github.com/tomochain/tomox-sdk/types"
+	"time"
 )
 
 type MongoItem struct {
@@ -247,38 +245,9 @@ func (db *MongoDatabase) InitDryRunMode() {
 	db.dryRunCache.Purge()
 }
 
-//TODO: should use batch commit to avoid data inconsistency
 func (db *MongoDatabase) SaveDryRunResult() error {
-
-	sc := db.Session.Copy()
-	defer sc.Close()
-
-	for _, cacheKey := range db.dryRunCache.Keys() {
-		key, err := hex.DecodeString(cacheKey.(string))
-		if err != nil {
-			log.Error("Can't save dry-run result (hex.DecodeString)", "err", err)
-			return err
-		}
-		val, ok := db.dryRunCache.Get(cacheKey)
-		if !ok {
-			err := errors.New("can't get item from dryrun cache")
-			log.Error("Can't save dry-run result (db.dryRunCache.Get)", "err", err)
-			return err
-		}
-		if val == nil {
-			//TODO: don't remove order item in mongo
-			if err := db.Delete(key,false); err != nil {
-				log.Error("Can't save dry-run result (db.Delete)", "err", err)
-				return err
-			}
-			continue
-		}
-		if err := db.Put(key, val, false); err != nil {
-			log.Error("Can't save dry-run result (db.Put)", "err", err)
-			return err
-		}
-	}
-	// purge cache data
+	// SDK node (which running with mongodb) doesn't run Matching engine
+	// dry-run cache is useless for sdk node
 	db.dryRunCache.Purge()
 	return nil
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -300,7 +300,7 @@ func (db *MongoDatabase) CommitOrder(cacheKey string, o *OrderItem) error {
 		return err
 	}
 
-	log.Debug("Save", "cacheKey", cacheKey, "value", ToJSON(o))
+	log.Debug("Save orderItem", "cacheKey", cacheKey, "value", ToJSON(o))
 
 	return nil
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	sdktypes "github.com/tomochain/tomox-sdk/types"
 	"math/big"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"encoding/hex"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -19,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"golang.org/x/sync/syncmap"
 	"gopkg.in/fatih/set.v0"
-	"encoding/hex"
 )
 
 const (
@@ -57,14 +58,15 @@ type Config struct {
 }
 
 type TxDataMatch struct {
-	Order  []byte
-	Trades []map[string]string
-	ObOld  common.Hash
-	ObNew  common.Hash
-	AskOld common.Hash
-	AskNew common.Hash
-	BidOld common.Hash
-	BidNew common.Hash
+	Order       []byte
+	Trades      []map[string]string
+	OrderInBook []byte
+	ObOld       common.Hash
+	ObNew       common.Hash
+	AskOld      common.Hash
+	AskNew      common.Hash
+	BidOld      common.Hash
+	BidNew      common.Hash
 }
 
 // DefaultConfig represents (shocker!) the default configuration.
@@ -799,7 +801,7 @@ func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
 				if order != nil {
 					if !tomox.existProcessedOrderHash(orderHash) {
 						var (
-							ob *OrderBook
+							ob  *OrderBook
 							err error
 						)
 
@@ -832,7 +834,7 @@ func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
 							log.Error("Can't encode", "order", order, "err", err)
 							continue
 						}
-						trades, _, err := ob.ProcessOrder(order, true, true)
+						trades, orderInBook, err := ob.ProcessOrder(order, true, true)
 						if err != nil {
 							log.Error("Can't process order", "order", order, "err", err)
 							continue
@@ -852,17 +854,25 @@ func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
 							log.Error("Fail to get bid tree hash new", "err", err)
 							continue
 						}
-
-						log.Info("Process OrderPending completed", "obNew", hex.EncodeToString(obNew.Bytes()), "bidNew", hex.EncodeToString(bidNew.Bytes()), "askNew", hex.EncodeToString(askNew.Bytes()))
+						orderInBookValue := []byte{}
+						if orderInBook != nil {
+							orderInBookValue, err = EncodeBytesItem(orderInBook)
+							if err != nil {
+								log.Error("Can't encode orderInBook", "orderInBook", orderInBook, "err", err)
+								continue
+							}
+						}
+						log.Debug("Process OrderPending completed", "obNew", hex.EncodeToString(obNew.Bytes()), "bidNew", hex.EncodeToString(bidNew.Bytes()), "askNew", hex.EncodeToString(askNew.Bytes()))
 						txMatches[order.Hash] = TxDataMatch{
-							Order:  value,
-							Trades: trades,
-							ObOld:  obOld,
-							ObNew:  obNew,
-							AskOld: askOld,
-							AskNew: askNew,
-							BidOld: bidOld,
-							BidNew: bidNew,
+							Order:       value,
+							Trades:      trades,
+							OrderInBook: orderInBookValue,
+							ObOld:       obOld,
+							ObNew:       obNew,
+							AskOld:      askOld,
+							AskNew:      askNew,
+							BidOld:      bidOld,
+							BidNew:      bidNew,
 						}
 					}
 				} else {
@@ -1230,15 +1240,86 @@ func (tomox *TomoX) loadSnapshot(hash common.Hash) error {
 // save orderbook after matching orders
 // update order pending list, processed list
 func (tomox *TomoX) ApplyTxMatches(orderHashes []common.Hash) error {
-	if err := tomox.db.SaveDryRunResult(); err != nil {
-		log.Error("Failed to save dry-run result")
-		return err
+	if !tomox.IsSDKNode() {
+		if err := tomox.db.SaveDryRunResult(); err != nil {
+			log.Error("Failed to save dry-run result")
+			return err
+		}
 	}
+
 	for _, hash := range orderHashes {
 		if err := tomox.MarkOrderAsProcessed(hash); err != nil {
 			log.Error("Failed to mark order as processed", "err", err)
 		}
 	}
 	tomox.db.InitDryRunMode()
+	return nil
+}
+
+func (tomox *TomoX) SyncDataToSDKNode(txDataMatch *TxDataMatch, txHash common.Hash) error {
+	// put tradeSDK to mongodb on SDK node only
+	if !tomox.IsSDKNode() {
+		return nil
+	}
+	var (
+		order, orderInBook *OrderItem
+		err                error
+	)
+	if order, err = txDataMatch.DecodeOrder(); err != nil {
+		log.Error("SDK node decode order failed", "txDataMatch", txDataMatch)
+		return fmt.Errorf("SDK node decode order failed")
+	}
+	if orderInBook, err = txDataMatch.DecodeOrderInBook(); err != nil {
+		log.Error("SDK node decode orderInBook failed", "txDataMatch", txDataMatch)
+		return fmt.Errorf("SDK node decode orderInBook failed")
+	}
+
+	db := tomox.GetDB()
+	trades := txDataMatch.GetTrades()
+	log.Debug("Got trades", "number", len(trades), "trades", trades)
+	for _, trade := range trades {
+
+		// insert to trades
+		tradeSDK := &sdktypes.Trade{}
+		if q, ok := trade["quantity"]; ok {
+			tradeSDK.Amount = new(big.Int)
+			tradeSDK.Amount.SetString(q, 10)
+		}
+		tradeSDK.PricePoint = order.Price
+		tradeSDK.PairName = order.PairName
+		tradeSDK.BaseToken = order.BaseToken
+		tradeSDK.QuoteToken = order.QuoteToken
+		tradeSDK.Status = sdktypes.TradeStatusSuccess
+		tradeSDK.Maker = order.UserAddress
+		tradeSDK.MakerOrderHash = order.Hash
+		if u, ok := trade["uAddr"]; ok {
+			tradeSDK.Taker = common.Address{}
+			tradeSDK.Taker.SetString(u)
+		}
+		tradeSDK.TakerOrderHash = order.Hash //FIXME: will update txMatch to include TakerOrderHash = headOrder.Item.Hash
+		tradeSDK.TxHash = txHash
+		tradeSDK.Hash = tradeSDK.ComputeHash()
+		log.Debug("TRADE history", "order", order, "trade", tradeSDK)
+		if err := db.Put(EmptyKey(), tradeSDK, false); err != nil {
+			return fmt.Errorf("SDKNode: failed to store tradeSDK %s", err.Error())
+		}
+
+		// remove from orders
+		orderHashBytes, err := hex.DecodeString(trade["orderHash"])
+		if err != nil {
+			return fmt.Errorf("SDKNode: failed to decode orderKey. Key: %s", trade["orderHash"])
+		}
+		log.Debug("SDKNode: try to remove matched order from orders collection", "orderHash", trade["orderHash"])
+		if err := db.Delete(orderHashBytes, false); err != nil {
+			return fmt.Errorf("SDKNode: failed to remove matched order from orders collection %s", trade["orderHash"])
+		}
+	}
+
+	if orderInBook != nil {
+		log.Debug("store orderInBook", "order", orderInBook)
+		if err = db.Put(orderInBook.Hash.Bytes(), orderInBook, false); err != nil {
+			return fmt.Errorf("SDKNode: failed to store orderInBook to sdkNode %s", err.Error())
+		}
+	}
 	return nil
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1257,7 +1257,7 @@ func (tomox *TomoX) ApplyTxMatches(orderHashes []common.Hash) error {
 }
 
 func (tomox *TomoX) SyncDataToSDKNode(txDataMatch *TxDataMatch, txHash common.Hash) error {
-	// put tradeSDK to mongodb on SDK node only
+	// put trade output to mongodb on SDK node only
 	if !tomox.IsSDKNode() {
 		return nil
 	}

--- a/tomox/validator.go
+++ b/tomox/validator.go
@@ -268,3 +268,14 @@ func (tx *TxDataMatch) DecodeOrder() (*OrderItem, error) {
 func (tx *TxDataMatch) GetTrades() []map[string]string {
 	return tx.Trades
 }
+
+func (tx *TxDataMatch) DecodeOrderInBook() (*OrderItem, error) {
+	if len(tx.OrderInBook) == 0 {
+		return nil, nil
+	}
+	orderInBook := &OrderItem{}
+	if err := DecodeBytesItem(tx.OrderInBook, orderInBook); err != nil {
+		return orderInBook, err
+	}
+	return orderInBook, nil
+}


### PR DESCRIPTION
**New `TxDataMatch` structure**
```go
type TxDataMatch struct {
	Order       []byte
	Trades      []map[string]string
	OrderInBook []byte  // new update
	ObOld       common.Hash
	ObNew       common.Hash
	AskOld      common.Hash
	AskNew      common.Hash
	BidOld      common.Hash
	BidNew      common.Hash
}
```
Note: orderInBook is the new order inserting/updating to orderTree(bid/ask)

**SDK nodes scenario:**
- Receive block containing txMatch, capture orderHash, don't run matching engine
- InsertBlock: removeOrderPending, removePending with the above orderHash
- Insert `orderInBook` to `orders` collection
- For each trades:
     + Remove matchedOrder from `order` by trade["orderHash"]
     + Insert `trades` to `trades` collection 