### PR TITLE
SDK nodes keep all orders

### DIFF
--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -256,7 +256,9 @@ func (db *MongoDatabase) CommitOrder(cacheKey string, o *OrderItem) error {
 	defer sc.Close()
 
 	// Store the key
-	o.Key = cacheKey
+	if len(o.Key) == 0 {
+		o.Key = cacheKey
+	}
 
 	query := bson.M{"key": cacheKey}
 

--- a/tomox/orderbook.go
+++ b/tomox/orderbook.go
@@ -413,7 +413,8 @@ func (orderBook *OrderBook) processOrderList(side string, orderList *OrderList, 
 		}
 
 		transactionRecord := make(map[string]string)
-		transactionRecord["orderHash"] = hex.EncodeToString(headOrder.Item.Hash.Bytes())
+		transactionRecord["takerOrderHash"] = hex.EncodeToString(order.Hash.Bytes())
+		transactionRecord["makerOrderHash"] = hex.EncodeToString(headOrder.Item.Hash.Bytes())
 		transactionRecord["timestamp"] = strconv.FormatUint(orderBook.Timestamp, 10)
 		transactionRecord["quantity"] = tradedQuantity.String()
 		transactionRecord["exAddr"] = headOrder.Item.ExchangeAddress.String()


### PR DESCRIPTION
Fix #593 
**Orders flow in SDK nodes:** NEW -> OPEN -> PARTIAL_FILLED (optional) -> FILLED
- New order is added to database with pending prefix ( `orders` collection)
- Order is processed in block and push to orderTree but not matched any order yet. In this case, SDK nodes update key of order in database  (`orders` collection) to remove pending prefix, also update status from `NEW` to `OPEN`
- Order matches other order(s), generate a new trade then SDK nodes update  both taker, maker order status to `FILLED` and put new trades to `trades` collection
- If order status is FILLED (mean that it already matched) but still exists in orderbook, then update status to `PARTIAL_FILLED`