### PR TITLE
Batch multiple TxDataMatches into one tx

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/tomox"
+	"sort"
 )
 
 // BlockValidator is responsible for validating block headers, uncles and
@@ -96,6 +97,10 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 			txs = append(txs, tx)
 		}
 	}
+
+	sort.Slice(txs, func(i, j int) bool {
+		return txs[i].Timestamp() <= txs[j].Timestamp()
+	})
 
 	for _, tx := range txs {
 		if tx.IsMatchingTransaction() {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -105,7 +105,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		// Try and process the block
 		err := blockchain.engine.VerifyHeader(blockchain, block.Header(), true)
 		if err == nil {
-			err, _ = blockchain.validator.ValidateBody(block)
+			err = blockchain.validator.ValidateBody(block)
 		}
 		if err != nil {
 			if err == ErrKnownBlock {

--- a/core/types.go
+++ b/core/types.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -29,7 +28,7 @@ import (
 //
 type Validator interface {
 	// ValidateBody validates the given block's content.
-	ValidateBody(block *types.Block) (error, []common.Hash)
+	ValidateBody(block *types.Block) error
 
 	// ValidateState validates the given statedb and optionally the receipts and
 	// gas used.

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -213,3 +213,19 @@ func IsEqualOrGreaterThan(x, y *big.Int) bool {
 func IsEqualOrSmallerThan(x, y *big.Int) bool {
 	return (IsEqual(x, y) || IsSmallerThan(x, y))
 }
+
+func EncodeTxMatchesBatch(txMatchResult []TxDataMatch) ([]byte, error) {
+	data, err := json.Marshal(txMatchResult)
+	if err != nil || data == nil {
+		return []byte{}, err
+	}
+	return data, nil
+}
+
+func DecodeTxMatchesBatch(data []byte) ([]TxDataMatch, error) {
+	txMatchResult := []TxDataMatch{}
+	if err := json.Unmarshal(data, &txMatchResult); err != nil {
+		return []TxDataMatch{}, err
+	}
+	return txMatchResult, nil
+}

--- a/tomox/common_test.go
+++ b/tomox/common_test.go
@@ -1,0 +1,66 @@
+package tomox
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"reflect"
+	"testing"
+)
+
+// Testing scenario:
+// encode originalTxMatchesBatch -> byteData
+// decode byteData -> txMatchesBatch
+// compare originalTxMatchesBatch and txMatchesBatch
+func TestTxMatchesBatch(t *testing.T) {
+	originalTxMatchesBatch := []TxDataMatch{
+		{
+			Order:       []byte("order1"),
+			Trades:      []map[string]string{{"takerOrderHash": "hash11"}, {"takerOrderHash": "hash12"}},
+			OrderInBook: []byte("order1'"),
+			ObOld:       common.StringToHash("ObOld1"),
+			ObNew:       common.StringToHash("ObNew1"),
+			AskOld:      common.StringToHash("AskOld1"),
+			AskNew:      common.StringToHash("AskNew1"),
+			BidOld:      common.StringToHash("BidOld1"),
+			BidNew:      common.StringToHash("BidNew1"),
+		},
+		{
+			Order:       []byte("order2"),
+			Trades:      []map[string]string{{"takerOrderHash": "hash21"}, {"takerOrderHash": "hash22"}},
+			OrderInBook: []byte("order2'"),
+			ObOld:       common.StringToHash("ObOld2"),
+			ObNew:       common.StringToHash("ObNew2"),
+			AskOld:      common.StringToHash("AskOld2"),
+			AskNew:      common.StringToHash("AskNew2"),
+			BidOld:      common.StringToHash("BidOld2"),
+			BidNew:      common.StringToHash("BidNew2"),
+		},
+		{
+			Order:       []byte("order3"),
+			Trades:      []map[string]string{{"takerOrderHash": "hash31"}, {"takerOrderHash": "hash32"}},
+			OrderInBook: []byte("order3'"),
+			ObOld:       common.StringToHash("ObOld3"),
+			ObNew:       common.StringToHash("ObNew3"),
+			AskOld:      common.StringToHash("AskOld3"),
+			AskNew:      common.StringToHash("AskNew3"),
+			BidOld:      common.StringToHash("BidOld3"),
+			BidNew:      common.StringToHash("BidNew3"),
+		},
+	}
+
+	encodedData, err := EncodeTxMatchesBatch(originalTxMatchesBatch)
+	if err != nil {
+		t.Error("Failed to encode", err.Error())
+	}
+
+	txMatchesBatch, err := DecodeTxMatchesBatch(encodedData)
+	if err != nil {
+		t.Error("Failed to decode", err.Error())
+	}
+
+	eq := reflect.DeepEqual(originalTxMatchesBatch, txMatchesBatch)
+	if eq {
+		t.Log("Awesome, encode and decode txMatchesBatch are correct")
+	} else {
+		t.Error("txMatchesBatch is different from originalTxMatchesBatch", "txMatchesBatch", txMatchesBatch, "originalTxMatchesBatch", originalTxMatchesBatch)
+	}
+}

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -48,7 +48,7 @@ const (
 	pendingHash          = "PENDING_HASH"
 	pendingPrefix        = "XP"
 	processedHash        = "PROCESSED_HASH"
-	orderProcessLimit    = 5
+	orderProcessLimit    = 10
 )
 
 type Config struct {
@@ -789,18 +789,18 @@ func (tomox *TomoX) GetAsksTree(pairName string, dryrun bool) (*OrderTree, error
 	return ob.Asks, nil
 }
 
-func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
-	txMatches := make(map[common.Hash]TxDataMatch)
+func (tomox *TomoX) ProcessOrderPending() []TxDataMatch {
+	txMatches := []TxDataMatch{}
 	tomox.db.InitDryRunMode()
 
 	log.Debug("Get pending hashes")
 	pendingHashes := tomox.getPendingHashes()
 	if len(pendingHashes) > 0 {
 		for i, orderHash := range pendingHashes {
-			if i <= orderProcessLimit {
+			if i < orderProcessLimit {
 				order := tomox.getOrderPending(orderHash)
 				if order != nil {
-					if !tomox.existProcessedOrderHash(orderHash) {
+					if !tomox.ExistProcessedOrderHash(orderHash) {
 						var (
 							ob  *OrderBook
 							err error
@@ -863,8 +863,8 @@ func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
 								continue
 							}
 						}
-						log.Debug("Process OrderPending completed", "obNew", hex.EncodeToString(obNew.Bytes()), "bidNew", hex.EncodeToString(bidNew.Bytes()), "askNew", hex.EncodeToString(askNew.Bytes()))
-						txMatches[order.Hash] = TxDataMatch{
+						log.Debug("Process OrderPending completed", "orderNonce", order.Nonce, "obNew", hex.EncodeToString(obNew.Bytes()), "bidNew", hex.EncodeToString(bidNew.Bytes()), "askNew", hex.EncodeToString(askNew.Bytes()))
+						txMatch := TxDataMatch{
 							Order:       value,
 							Trades:      trades,
 							OrderInBook: orderInBookValue,
@@ -875,6 +875,7 @@ func (tomox *TomoX) ProcessOrderPending() map[common.Hash]TxDataMatch {
 							BidOld:      bidOld,
 							BidNew:      bidNew,
 						}
+						txMatches = append(txMatches, txMatch)
 					}
 				} else {
 					log.Error("Fail to get order pending from db", "hash", orderHash)
@@ -1062,7 +1063,7 @@ func (tomox *TomoX) addProcessedOrderHash(orderHash common.Hash, limit int) erro
 	return nil
 }
 
-func (tomox *TomoX) existProcessedOrderHash(orderHash common.Hash) bool {
+func (tomox *TomoX) ExistProcessedOrderHash(orderHash common.Hash) bool {
 	processedHashes := tomox.getProcessedOrderHash()
 
 	for _, k := range processedHashes {

--- a/tomox/tomox_test.go
+++ b/tomox/tomox_test.go
@@ -413,7 +413,7 @@ func TestProcessedHash(t *testing.T) {
 		t.Error("Expected: 3 processed hash", "Actual:", len(pHashes), "pHashes", pHashes)
 	}
 
-	if !tomox.existProcessedOrderHash(common.StringToHash("0x0000000000000000000000000000000000000004")) {
+	if !tomox.ExistProcessedOrderHash(common.StringToHash("0x0000000000000000000000000000000000000004")) {
 		t.Error("Processed hash not exist")
 	}
 }


### PR DESCRIPTION
Change in this PR:
- Batch multiple TxDataMatches into one tx
- Append timestamp to matching transactions (transactions include TxDataMatch)
- In validateBody, sort matching transactions by timestamp