### PR TITLE
Add timestamp to txPayload instead of txData

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -233,12 +233,12 @@ func ApplyTomoXMatchedTransaction(config *params.ChainConfig, statedb *state.Sta
 		return nil, 0, ErrNonceTooLow
 	}
 
-	txMatches, err := tomox.DecodeTxMatchesBatch(tx.Data())
-	if err != nil {
+	txMatchBatches, err := tomox.DecodeTxMatchesBatch(tx.Data())
+	if err != nil || len(txMatchBatches.Data) == 0 {
 		return nil, 0, err
 	}
 	gasUsed := big.NewInt(0)
-	for _, txMatch := range txMatches {
+	for _, txMatch := range txMatchBatches.Data {
 		orderItem, err := txMatch.DecodeOrder()
 		if err != nil {
 			return nil, 0, err

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -616,7 +616,10 @@ func (self *worker) commitNewWork() {
 				if len(txMatches) > 0 {
 					log.Debug("transaction matches found", "txMatches", len(txMatches))
 					// put all TxMatchesData into only one tx
-					txMatchBytes, err := tomox.EncodeTxMatchesBatch(txMatches)
+					txMatchBytes, err := tomox.EncodeTxMatchesBatch(tomox.TxMatchBatch{
+						Data:      txMatches,
+						Timestamp: uint64(time.Now().UnixNano()),
+					})
 					if err != nil {
 						log.Error("Fail to marshal txMatch", "error", err)
 					} else {

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -214,18 +214,18 @@ func IsEqualOrSmallerThan(x, y *big.Int) bool {
 	return (IsEqual(x, y) || IsSmallerThan(x, y))
 }
 
-func EncodeTxMatchesBatch(txMatchResult []TxDataMatch) ([]byte, error) {
-	data, err := json.Marshal(txMatchResult)
+func EncodeTxMatchesBatch(txMatchBatch TxMatchBatch) ([]byte, error) {
+	data, err := json.Marshal(txMatchBatch)
 	if err != nil || data == nil {
 		return []byte{}, err
 	}
 	return data, nil
 }
 
-func DecodeTxMatchesBatch(data []byte) ([]TxDataMatch, error) {
-	txMatchResult := []TxDataMatch{}
+func DecodeTxMatchesBatch(data []byte) (TxMatchBatch, error) {
+	txMatchResult := TxMatchBatch{}
 	if err := json.Unmarshal(data, &txMatchResult); err != nil {
-		return []TxDataMatch{}, err
+		return TxMatchBatch{}, err
 	}
 	return txMatchResult, nil
 }

--- a/tomox/common_test.go
+++ b/tomox/common_test.go
@@ -47,7 +47,9 @@ func TestTxMatchesBatch(t *testing.T) {
 		},
 	}
 
-	encodedData, err := EncodeTxMatchesBatch(originalTxMatchesBatch)
+	encodedData, err := EncodeTxMatchesBatch(TxMatchBatch{
+		Data:      originalTxMatchesBatch,
+	})
 	if err != nil {
 		t.Error("Failed to encode", err.Error())
 	}
@@ -57,7 +59,7 @@ func TestTxMatchesBatch(t *testing.T) {
 		t.Error("Failed to decode", err.Error())
 	}
 
-	eq := reflect.DeepEqual(originalTxMatchesBatch, txMatchesBatch)
+	eq := reflect.DeepEqual(originalTxMatchesBatch, txMatchesBatch.Data)
 	if eq {
 		t.Log("Awesome, encode and decode txMatchesBatch are correct")
 	} else {

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -69,6 +69,11 @@ type TxDataMatch struct {
 	BidNew      common.Hash
 }
 
+type TxMatchBatch struct {
+	Data []TxDataMatch
+	Timestamp uint64
+}
+
 // DefaultConfig represents (shocker!) the default configuration.
 var DefaultConfig = Config{
 	DataDir: node.DefaultDataDir(),


### PR DESCRIPTION
txPayload will be JSON of the following struct

```go
type TxMatchBatch struct {
	Data []TxDataMatch
	Timestamp uint64
}
```

Tested scenario:
- Placed order, matched, generated trades, updated order statuses
- Transfered balance using metamask