### PR TITLE
Put cancel-order to block

### DIFF
--- a/tomox/orderbook.go
+++ b/tomox/orderbook.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
+	sdktypes "github.com/tomochain/tomox-sdk/types"
 )
 
 const (
@@ -327,6 +328,21 @@ func (orderBook *OrderBook) ProcessOrder(order *OrderItem, verbose bool, dryrun 
 	orderBook.UpdateTime()
 	// if we do not use auto-increment orderid, we must set price slot to avoid conflict
 	orderBook.Item.NextOrderID++
+
+	if order.Status == sdktypes.OrderStatusCancelled {
+		err := orderBook.CancelOrder(order, dryrun)
+		switch err {
+		case ErrDoesNotExist:
+			log.Debug("Order doesn't exist in tree", "order", order)
+			return nil, nil, nil
+		case nil:
+			log.Debug("Cancelled order", "order", order)
+			return nil, nil, nil
+		default:
+			log.Error("Can't cancel order", "order", order, "err", err)
+			return nil, nil, err
+		}
+	}
 
 	if orderType == Market {
 		log.Debug("Process market order", "order", order)

--- a/tomox/orderbook.go
+++ b/tomox/orderbook.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
-	sdktypes "github.com/tomochain/tomox-sdk/types"
 )
 
 const (
@@ -329,8 +328,8 @@ func (orderBook *OrderBook) ProcessOrder(order *OrderItem, verbose bool, dryrun 
 	// if we do not use auto-increment orderid, we must set price slot to avoid conflict
 	orderBook.Item.NextOrderID++
 
-	if order.Status == sdktypes.OrderStatusCancelled {
-		err := orderBook.CancelOrder(order, dryrun)
+	if order.Status == OrderStatusCancelled {
+		err := orderBook.CancelOrder(order, dryrun, blockHash)
 		switch err {
 		case ErrDoesNotExist:
 			log.Debug("Order doesn't exist in tree", "order", order)

--- a/tomox/tomox_test.go
+++ b/tomox/tomox_test.go
@@ -263,32 +263,32 @@ func TestDBPending(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	if pHashes := tomox.getPendingHashes(); len(pHashes) != 0 {
-		t.Error("Expected: no pending hash", "Actual:", len(pHashes))
+	if pending := tomox.getPendingOrders(); len(pending) != 0 {
+		t.Error("Expected: no pending hash", "Actual:", len(pending))
 	}
 
 	var hash common.Hash
 	hash = common.StringToHash("0x0000000000000000000000000000000000000000")
-	tomox.addPendingHash(hash)
+	tomox.addOrderToPending(hash, false)
 	hash = common.StringToHash("0x0000000000000000000000000000000000000001")
-	tomox.addPendingHash(hash)
+	tomox.addOrderToPending(hash, false)
 	hash = common.StringToHash("0x0000000000000000000000000000000000000002")
-	tomox.addPendingHash(hash)
+	tomox.addOrderToPending(hash, true)
 	// getPendingHashes from cache
-	if pHashes := tomox.getPendingHashes(); len(pHashes) != 3 {
-		t.Error("Expected: 3 pending hash", "Actual:", len(pHashes))
+	if pending := tomox.getPendingOrders(); len(pending) != 3 {
+		t.Error("Expected: 3 pending hash", "Actual:", len(pending))
 	}
 
 	// Test remove hash
 	hash = common.StringToHash("0x0000000000000000000000000000000000000002")
-	tomox.RemovePendingHash(hash)
+	tomox.RemoveOrderFromPending(hash, true)
 
-	if pHashes := tomox.getPendingHashes(); len(pHashes) != 2 {
-		t.Error("Expected: 2 pending hash", "Actual:", len(pHashes))
+	if pending := tomox.getPendingOrders(); len(pending) != 2 {
+		t.Error("Expected: 2 pending hash", "Actual:", len(pending))
 	}
 
 	order := buildOrder(new(big.Int).SetInt64(1))
-	tomox.addOrderPending(order)
+	tomox.saveOrderPendingToDB(order)
 	od := tomox.getOrderPending(order.Hash)
 	if od != nil && order.Hash.String() != od.Hash.String() {
 		t.Error("Fail to add order pending", "orderOld", order, "orderNew", od)


### PR DESCRIPTION
Cancel-order will be processed as same as new-order. M1 pick up cancel-order from pending queue and put into block (same ME procedure but trades and orderInBook are empty). Mi(s) validate block and remove cancel-order from tree. SDK node updates order status in mongo.