### PR TITLE
Tomox reorg

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -22,7 +22,6 @@ const (
 	MergeSignRange             = 15
 	RangeReturnSigner          = 150
 	MinimunMinerBlockPerEpoch  = 1
-	TomoXSnapshotInterval      = 100 // 100 blocks
 )
 
 var TIP2019Block = big.NewInt(1050000)

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -94,7 +94,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		head := v.bc.CurrentBlock()
 		if block.NumberU64() == head.NumberU64() && block.ParentHash() == head.ParentHash() {
 			// parent is splitting point, try to rollback tomox to parent
-			if err := v.bc.reorgTomox(block, []*types.Block{head}, []*types.Block{block}); err != nil {
+			if err := v.bc.reorgTomox(v.bc.GetBlockByNumber(block.NumberU64() - 1), []*types.Block{head}, []*types.Block{}); err != nil {
 				return err
 			}
 		}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -178,7 +178,7 @@ func (v *BlockValidator) validateMatchingOrder(tomoXService *tomox.TomoX, curren
 		}
 
 		// verify old state: orderbook hash, bidTree hash, askTree hash
-		if err := txMatch.VerifyOldTomoXState(ob); err != nil {
+		if err := txMatch.VerifyOldTomoXState(ob, true, blockHash); err != nil {
 			return err
 		}
 
@@ -188,7 +188,7 @@ func (v *BlockValidator) validateMatchingOrder(tomoXService *tomox.TomoX, curren
 		}
 
 		// verify new state
-		if err := txMatch.VerifyNewTomoXState(ob); err != nil {
+		if err := txMatch.VerifyNewTomoXState(ob, true, blockHash); err != nil {
 			return err
 		}
 	}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -93,7 +93,8 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if tomoXService != nil {
 		head := v.bc.CurrentBlock()
 		if block.NumberU64() <= head.NumberU64() {
-			if err := v.bc.reorgTomox(v.bc.GetBlockByNumber(head.NumberU64() - 1), []*types.Block{}, []*types.Block{}); err != nil {
+			if err := v.bc.LoadTomoxStateAtBlock(
+				block.NumberU64() - 1); err != nil {
 				return err
 			}
 		}
@@ -155,7 +156,7 @@ func (v *BlockValidator) validateMatchingOrder(tomoXService *tomox.TomoX, curren
 		if err != nil {
 			return fmt.Errorf("transaction match is corrupted. Failed decode order. Error: %s ", err)
 		}
-		if order.Status != tomox.OrderStatusCancelled && tomoXService.ExistProcessedOrderHash(order.Hash) {
+		if order.Status != tomox.OrderStatusCancelled && tomoXService.ExistProcessedOrderHash(order.Hash, blockHash) {
 			log.Debug("This order has been processed", "hash", hex.EncodeToString(order.Hash.Bytes()))
 			continue
 		}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -91,6 +91,13 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 
 	// clear the previous dry-run cache
 	if tomoXService != nil {
+		head := v.bc.CurrentBlock()
+		if block.NumberU64() == head.NumberU64() && block.ParentHash() == head.ParentHash() {
+			// parent is splitting point, try to rollback tomox to parent
+			if err := v.bc.reorgTomox(block); err != nil {
+				return err
+			}
+		}
 		tomoXService.GetDB().InitDryRunMode(hashNoValidator)
 	}
 	txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -94,7 +94,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		head := v.bc.CurrentBlock()
 		if block.NumberU64() == head.NumberU64() && block.ParentHash() == head.ParentHash() {
 			// parent is splitting point, try to rollback tomox to parent
-			if err := v.bc.reorgTomox(block); err != nil {
+			if err := v.bc.reorgTomox(block, []*types.Block{head}, []*types.Block{block}); err != nil {
 				return err
 			}
 		}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -162,15 +162,6 @@ func (v *BlockValidator) validateMatchingOrder(tomoXService *tomox.TomoX, curren
 		}
 		log.Debug("process tx match", "order", order)
 
-
-		// Remove order from db pending.
-		if err := tomoXService.RemoveOrderFromPending(order.Hash, order.Status == tomox.OrderStatusCancelled); err != nil {
-			log.Debug("Fail to remove pending hash", "err", err)
-		}
-		if err := tomoXService.RemoveOrderPendingFromDB(order.Hash, order.Status == tomox.OrderStatusCancelled); err != nil {
-			log.Debug("Fail to remove order pending", "err", err)
-		}
-
 		// SDK node doesn't need to run ME
 		if tomoXService.IsSDKNode() {
 			log.Debug("SDK node ignore running matching engine")

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -99,8 +99,12 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 
 	// clear the previous dry-run cache
 	if tomoXService != nil {
-		parent := v.bc.GetBlock(block.ParentHash(), block.NumberU64()-1)
-		tomoXService.GetDB().InitDryRunMode(hashNoValidator, v.bc.FindNearestDryrunCache(tomoXService, parent))
+		if (block.NumberU64()-1)%tomox.SnapshotInterval == 0 {
+			tomoXService.GetDB().InitDryRunMode(hashNoValidator, common.Hash{})
+		} else {
+			parent := v.bc.GetBlock(block.ParentHash(), block.NumberU64()-1)
+			tomoXService.GetDB().InitDryRunMode(hashNoValidator, v.bc.FindNearestDryrunCache(tomoXService, parent))
+		}
 	}
 	for _, txMatchBatch := range txMatchBatchData {
 		if tomoXService == nil {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -92,9 +92,8 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// clear the previous dry-run cache
 	if tomoXService != nil {
 		head := v.bc.CurrentBlock()
-		if block.NumberU64() == head.NumberU64() && block.ParentHash() == head.ParentHash() {
-			// parent is splitting point, try to rollback tomox to parent
-			if err := v.bc.reorgTomox(v.bc.GetBlockByNumber(block.NumberU64() - 1), []*types.Block{head}, []*types.Block{}); err != nil {
+		if block.NumberU64() <= head.NumberU64() {
+			if err := v.bc.reorgTomox(v.bc.GetBlockByNumber(head.NumberU64() - 1), []*types.Block{}, []*types.Block{}); err != nil {
 				return err
 			}
 		}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -100,10 +100,14 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// clear the previous dry-run cache
 	if tomoXService != nil {
 		if (block.NumberU64()-1)%tomox.SnapshotInterval == 0 {
-			tomoXService.GetDB().InitDryRunMode(hashNoValidator, common.Hash{})
+			if err := tomoXService.GetDB().InitDryRunMode(hashNoValidator, common.Hash{}); err != nil {
+				return err
+			}
 		} else {
 			parent := v.bc.GetBlock(block.ParentHash(), block.NumberU64()-1)
-			tomoXService.GetDB().InitDryRunMode(hashNoValidator, v.bc.FindNearestDryrunCache(tomoXService, parent))
+			if err := tomoXService.GetDB().InitDryRunMode(hashNoValidator, v.bc.FindNearestDryrunCache(tomoXService, parent)); err != nil {
+				return err
+			}
 		}
 	}
 	for _, txMatchBatch := range txMatchBatchData {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -92,9 +92,8 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	// clear the previous dry-run cache
 	if tomoXService != nil {
 		head := v.bc.CurrentBlock()
-		if block.NumberU64() <= head.NumberU64() {
-			if err := v.bc.LoadTomoxStateAtBlock(
-				block.NumberU64() - 1); err != nil {
+		if block.ParentHash() != head.Hash() {
+			if err := v.bc.LoadTomoxStateAtBlock(block.ParentHash()); err != nil {
 				return err
 			}
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2256,7 +2256,7 @@ func (bc *BlockChain) FindNearestDryrunCache(tomoXService *tomox.TomoX, block *t
 }
 
 func getProcessedOrders(txMatchBatchData []tomox.TxMatchBatch) ([]*tomox.OrderItem, error) {
-	orders := []*tomox.OrderItem{}
+	var orders []*tomox.OrderItem
 	for _, txMatchBatch := range txMatchBatchData {
 		for _, txMatch := range txMatchBatch.Data {
 			order, err := txMatch.DecodeOrder()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2135,6 +2135,9 @@ func (bc *BlockChain) reorgTomox(block *types.Block, oldChain, newChain types.Bl
 		// Apply new chain
 		for i := len(newChain) - 1; i >= 0; i-- {
 			newBlock := newChain[i]
+			if err := bc.validator.ValidateBody(newBlock); err != nil {
+				return err
+			}
 			txMatchBatchData, err := ExtractMatchingTransactions(newBlock.Transactions())
 			if err != nil {
 				return err
@@ -2223,7 +2226,6 @@ func (bc *BlockChain) LoadTomoxStateAtBlock(tomoXService *tomox.TomoX, block *ty
 	}
 	for i := len(gapChain) - 1; i >= 0; i-- {
 		b := gapChain[i]
-		log.Debug("Rollback tomox states to block", "number", b.NumberU64(), "hash", b.Hash())
 		if b.NumberU64()%tomox.SnapshotInterval == 0 {
 			nearestDryrunCacheHash := bc.FindNearestDryrunCache(tomoXService, b)
 			log.Debug("From LoadTomoxStateAtBlock: Periodically save dryruncache to DB", "nearestDryrunCacheHash", nearestDryrunCacheHash)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2122,6 +2122,11 @@ func (bc *BlockChain) reorgTomox(block *types.Block, oldChain, newChain types.Bl
 	if tomoXService == nil {
 		return nil
 	}
+
+	defer func(start time.Time) {
+		log.Debug("reorgTomox takes ", "time", common.PrettyDuration(time.Since(start)))
+	}(time.Now())
+
 	// For masternode:
 	if !tomoXService.IsSDKNode() {
 		// rollback snapshot to commonBlock
@@ -2189,6 +2194,11 @@ func (bc *BlockChain) LoadTomoxStateAtBlock(blockhash common.Hash) error {
 	if tomoXService == nil {
 		return nil
 	}
+
+	defer func(start time.Time) {
+		log.Debug("LoadTomoxStateAtBlock takes ", "time", common.PrettyDuration(time.Since(start)))
+	}(time.Now())
+
 	gapChain := types.Blocks{}
 	b := bc.GetBlockByHash(blockhash)
 	if b == nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1610,10 +1610,6 @@ func (bc *BlockChain) insertBlock(block *types.Block) ([]interface{}, []*types.L
 				if err != nil {
 					return events, coalescedLogs, err
 				}
-				txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())
-				if err != nil {
-					return events, coalescedLogs, err
-				}
 				if err := logDataToSdkNode(tomoXService, txMatchBatchData, currentState); err != nil {
 					return events, coalescedLogs, err
 				}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1333,7 +1333,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				if err = tomoXService.ApplyTxMatches(processedOrders, block.HashNoValidator()); err != nil {
 					return i, events, coalescedLogs, err
 				}
-				if tomoXService.IsSDKNode() {
+				if tomoXService.IsSDKNode() && status == CanonStatTy {
 					currentState, err := bc.State()
 					if err != nil {
 						return i, events, coalescedLogs, err
@@ -1605,7 +1605,7 @@ func (bc *BlockChain) insertBlock(block *types.Block) ([]interface{}, []*types.L
 			if err = tomoXService.ApplyTxMatches(processedOrders, block.HashNoValidator()); err != nil {
 				return events, coalescedLogs, err
 			}
-			if tomoXService.IsSDKNode() {
+			if tomoXService.IsSDKNode() && status == CanonStatTy {
 				currentState, err := bc.State()
 				if err != nil {
 					return events, coalescedLogs, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -428,10 +428,10 @@ func ApplyTomoXMatchedTransaction(config *params.ChainConfig, bc *BlockChain, st
 	receipt.GasUsed = gasUsed.Uint64()
 	// if the transaction created a contract, store the creation address in the receipt.
 	// Set the receipt logs and create a bloom for filtering
-	log := &types.Log{}
-	log.Address = common.HexToAddress(common.BlockSigners)
-	log.BlockNumber = header.Number.Uint64()
-	statedb.AddLog(log)
+	stateLog := &types.Log{}
+	stateLog.Address = common.HexToAddress(common.TomoXAddr)
+	stateLog.BlockNumber = header.Number.Uint64()
+	statedb.AddLog(stateLog)
 	receipt.Logs = statedb.GetLogs(tx.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	return receipt, 0, nil, false

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -283,6 +283,7 @@ func ApplySignTransaction(config *params.ChainConfig, statedb *state.StateDB, he
 }
 
 func ApplyTomoXMatchedTransaction(config *params.ChainConfig, bc *BlockChain, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64) (*types.Receipt, uint64, error, bool) {
+	log.Debug("ApplyTomoXMatchedTransaction")
 	// Update the state with pending changes
 	from, err := types.Sender(types.MakeSigner(config, header.Number), tx)
 	if err != nil {
@@ -319,7 +320,7 @@ func ApplyTomoXMatchedTransaction(config *params.ChainConfig, bc *BlockChain, st
 			makerExfee := tomox.GetExRelayerFee(makerExAddr, statedb)
 			makerExOwner := tomox.GetRelayerOwner(makerExAddr, statedb)
 			makerAddr := common.HexToAddress(txMatch.Trades[i][tomox.TradeMaker])
-			log.Debug("ApplyTomoXMatchedTransaction : trades quantityString", "i", i, "trade", txMatch.Trades[i], "price", price)
+			//log.Debug("ApplyTomoXMatchedTransaction : trades quantityString", "i", i, "trade", txMatch.Trades[i], "price", price)
 			if makerExAddr != (common.Address{}) && makerAddr != (common.Address{}) {
 				// take relayer fee
 				err := tomox.SubRelayerFee(takerExAddr, common.RelayerFee, statedb)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -602,7 +602,6 @@ func (self *worker) commitNewWork() {
 	feeCapacity := state.GetTRC21FeeCapacityFromStateWithCache(parent.Root(), work.state)
 	if self.config.Posv != nil && header.Number.Uint64()%self.config.Posv.Epoch != 0 {
 		tomoX := self.eth.GetTomoX()
-
 		if tomoX != nil && header.Number.Uint64() > self.config.Posv.Epoch {
 			manager := self.eth.AccountManager()
 			if manager != nil {
@@ -620,7 +619,7 @@ func (self *worker) commitNewWork() {
 				orderPending, err := self.eth.OrderPool().Pending()
 				if err == nil {
 					log.Debug("Start processing order pending", "len", len(orderPending))
-					txMatches := tomoX.ProcessOrderPending(orderPending)
+					txMatches := tomoX.ProcessOrderPending(orderPending, self.chain.FindNearestDryrunCache(tomoX, self.chain.CurrentBlock()))
 					if len(txMatches) > 0 {
 						log.Debug("transaction matches found", "txMatches", len(txMatches))
 						// put all TxMatchesData into only one tx

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -619,7 +619,11 @@ func (self *worker) commitNewWork() {
 				orderPending, err := self.eth.OrderPool().Pending()
 				if err == nil {
 					log.Debug("Start processing order pending", "len", len(orderPending))
-					txMatches := tomoX.ProcessOrderPending(orderPending, self.chain.FindNearestDryrunCache(tomoX, self.chain.CurrentBlock()))
+					parentCacheHash := common.Hash{}
+					if self.chain.CurrentBlock().NumberU64()%tomox.SnapshotInterval != 0 {
+						parentCacheHash = self.chain.FindNearestDryrunCache(tomoX, self.chain.CurrentBlock())
+					}
+					txMatches := tomoX.ProcessOrderPending(orderPending, parentCacheHash)
 					if len(txMatches) > 0 {
 						log.Debug("transaction matches found", "txMatches", len(txMatches))
 						// put all TxMatchesData into only one tx

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -144,7 +144,7 @@ func (db *BatchDatabase) Put(key []byte, val interface{}, dryrun bool, blockHash
 		db.lock.Lock()
 		dryrunCache, ok := db.dryRunCaches[blockHash]
 		db.lock.Unlock()
-		if !ok  {
+		if !ok {
 			log.Debug("BatchDB - Put: DryrunCache of this block is not initialized. Initialize now!", "blockHash", blockHash)
 			db.InitDryRunMode(blockHash)
 			dryrunCache, _ = db.dryRunCaches[blockHash]
@@ -171,7 +171,7 @@ func (db *BatchDatabase) Delete(key []byte, dryrun bool, blockHash common.Hash) 
 		db.lock.Lock()
 		dryrunCache, ok := db.dryRunCaches[blockHash]
 		db.lock.Unlock()
-		if !ok  {
+		if !ok {
 			log.Debug("BatchDB - Delete: DryrunCache of this block is not initialized. Initialize now!", "blockHash", blockHash)
 			db.InitDryRunMode(blockHash)
 			dryrunCache, _ = db.dryRunCaches[blockHash]

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultCacheLimit = 1024000
-	dryrunCacheLimit = 200
+	dryrunCacheLimit  = 200
 )
 
 type BatchItem struct {
@@ -271,10 +271,14 @@ func (db *BatchDatabase) InitDryRunMode(blockHashNoValidator, parentCacheHash co
 
 				}
 			}
+		} else {
+			return fmt.Errorf("can't found parentCache . blockhash: %v .ParentCache %v", blockHashNoValidator, parentCacheHash)
 		}
 	}
 	db.dryRunCaches[blockHashNoValidator] = dryrunCache
-	db.recentCaches = append(db.recentCaches, blockHashNoValidator)
+	if blockHashNoValidator != M1DryrunCacheHash {
+		db.recentCaches = append(db.recentCaches, blockHashNoValidator)
+	}
 	return nil
 }
 

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -109,6 +109,9 @@ func (db *BatchDatabase) Get(key []byte, val interface{}, dryrun bool, blockHash
 		db.lock.Unlock()
 		if ok && dryrunCache.Len() > 0 {
 			if value, ok := dryrunCache.Get(cacheKey); ok {
+				if value == nil {
+					log.Debug("Key not found in dryruncache", "key", hex.EncodeToString(key), "blockhash", blockHash.Hex())
+				}
 				return value, nil
 			}
 		}

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -80,8 +80,13 @@ func (db *BatchDatabase) Has(key []byte, dryrun bool, blockHash common.Hash) (bo
 		db.lock.Lock()
 		dryrunCache, ok := db.dryRunCaches[blockHash]
 		db.lock.Unlock()
-		if ok && dryrunCache.Len() >= 0 && dryrunCache.Contains(cacheKey) {
-			return true, nil
+		if ok && dryrunCache.Len() > 0 {
+			if val, ok := dryrunCache.Get(cacheKey); ok {
+				if val == nil {
+					return false, nil
+				}
+				return true, nil
+			}
 		}
 	} else if db.cacheItems.Contains(cacheKey) {
 		// for dry-run mode, do not read cacheItems
@@ -102,7 +107,7 @@ func (db *BatchDatabase) Get(key []byte, val interface{}, dryrun bool, blockHash
 		db.lock.Lock()
 		dryrunCache, ok := db.dryRunCaches[blockHash]
 		db.lock.Unlock()
-		if ok && dryrunCache.Len() >= 0 {
+		if ok && dryrunCache.Len() > 0 {
 			if value, ok := dryrunCache.Get(cacheKey); ok {
 				return value, nil
 			}

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -253,3 +253,7 @@ func (db *BatchDatabase) SaveDryRunResult(blockHash common.Hash) error {
 	db.cacheItems.Purge()
 	return batch.Write()
 }
+
+func (db *BatchDatabase) DeleteTxMatchByTxHash(txhash common.Hash) error {
+	return nil
+}

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -45,6 +45,8 @@ var (
 )
 
 var (
+	M1DryrunCacheHash = common.StringToHash("COMMIT_NEW_WORK")
+
 	// errors
 	ErrUnsupportedEngine    = errors.New("only POSV supports matching orders")
 	ErrTomoXServiceNotFound = errors.New("can't attach tomoX service")

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -8,7 +8,7 @@ type OrderDao interface {
 	Get(key []byte, val interface{}, dryrun bool, blockHash common.Hash) (interface{}, error)
 	Put(key []byte, val interface{}, dryrun bool, blockHash common.Hash) error
 	Delete(key []byte, dryrun bool, blockHash common.Hash) error // won't return error if key not found
-	InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash)
+	InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash) error
 	HasDryrunCache(blockhash common.Hash) bool
 	DropDryrunCache(blockhash common.Hash)
 	SaveDryRunResult(blockHash common.Hash) error

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -8,7 +8,9 @@ type OrderDao interface {
 	Get(key []byte, val interface{}, dryrun bool, blockHash common.Hash) (interface{}, error)
 	Put(key []byte, val interface{}, dryrun bool, blockHash common.Hash) error
 	Delete(key []byte, dryrun bool, blockHash common.Hash) error // won't return error if key not found
-	InitDryRunMode(blockHash common.Hash)
+	InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash)
+	HasDryrunCache(blockhash common.Hash) bool
+	DropDryrunCache(blockhash common.Hash)
 	SaveDryRunResult(blockHash common.Hash) error
 	DeleteTxMatchByTxHash(txhash common.Hash) error
 }

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -10,4 +10,5 @@ type OrderDao interface {
 	Delete(key []byte, dryrun bool, blockHash common.Hash) error // won't return error if key not found
 	InitDryRunMode(blockHash common.Hash)
 	SaveDryRunResult(blockHash common.Hash) error
+	DeleteTxMatchByTxHash(txhash common.Hash) error
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -312,12 +312,5 @@ func (db *MongoDatabase) DeleteTxMatchByTxHash(txhash common.Hash) error {
 		log.Error("Error when deleting order in DeleteTxMatchByTxHash", "error", err)
 		return err
 	}
-
-	err = sc.DB(db.dbName).C(collectionNameTrades).Remove(query)
-	if err != nil && err != mgo.ErrNotFound {
-		log.Error("Error when deleting trade in DeleteTxMatchByTxHash", "error", err)
-		return err
-	}
-
 	return nil
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -216,7 +216,7 @@ func (db *MongoDatabase) Delete(key []byte, dryrun bool, blockHash common.Hash) 
 	return nil
 }
 
-func (db *MongoDatabase) InitDryRunMode(hash common.Hash) {
+func (db *MongoDatabase) InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash) {
 	// SDK node (which running with mongodb) doesn't run Matching engine
 	// dry-run cache is useless for sdk node
 }
@@ -301,6 +301,10 @@ func (db *MongoDatabase) CommitItem(cacheKey string, val interface{}) error {
 	return nil
 }
 
+func (db *MongoDatabase) HasDryrunCache(blockhash common.Hash) bool {
+	return false
+}
+
 func (db *MongoDatabase) DeleteTxMatchByTxHash(txhash common.Hash) error {
 	sc := db.Session.Copy()
 	defer sc.Close()
@@ -313,4 +317,8 @@ func (db *MongoDatabase) DeleteTxMatchByTxHash(txhash common.Hash) error {
 		return err
 	}
 	return nil
+}
+
+
+func (db *MongoDatabase) DropDryrunCache(blockhash common.Hash) {
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -294,3 +294,24 @@ func (db *MongoDatabase) CommitItem(cacheKey string, val interface{}) error {
 	log.Debug("Save", "cacheKey", cacheKey, "value", ToJSON(common.Bytes2Hex(data)))
 	return nil
 }
+
+func (db *MongoDatabase) DeleteTxMatchByTxHash(txhash common.Hash) error {
+	sc := db.Session.Copy()
+	defer sc.Close()
+
+	query := bson.M{"txHash": txhash}
+
+	err := sc.DB(db.dbName).C("orders").Remove(query)
+	if err != nil && err != mgo.ErrNotFound {
+		log.Error("Error when deleting order in DeleteTxMatchByTxHash", "error", err)
+		return err
+	}
+
+	err = sc.DB(db.dbName).C("trades").Remove(query)
+	if err != nil && err != mgo.ErrNotFound {
+		log.Error("Error when deleting trade in DeleteTxMatchByTxHash", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -261,8 +261,9 @@ func (db *MongoDatabase) CommitTrade(t *Trade) error {
 	sc := db.Session.Copy()
 	defer sc.Close()
 
-	t.ID = bson.NewObjectId()
-	t.CreatedAt = time.Now()
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = time.Now()
+	}
 	t.UpdatedAt = time.Now()
 
 	query := bson.M{"hash": t.Hash.Hex()}

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -216,9 +216,10 @@ func (db *MongoDatabase) Delete(key []byte, dryrun bool, blockHash common.Hash) 
 	return nil
 }
 
-func (db *MongoDatabase) InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash) {
+func (db *MongoDatabase) InitDryRunMode(blockHashNoValidator, parentHashNoValidator common.Hash) error {
 	// SDK node (which running with mongodb) doesn't run Matching engine
 	// dry-run cache is useless for sdk node
+	return nil
 }
 
 func (db *MongoDatabase) SaveDryRunResult(hash common.Hash) error {

--- a/tomox/mongodb_encoding.go
+++ b/tomox/mongodb_encoding.go
@@ -20,6 +20,7 @@ func (o *OrderItem) GetBSON() (interface{}, error) {
 		Side:            o.Side,
 		Type:            o.Type,
 		Hash:            o.Hash.Hex(),
+		TxHash:          o.TxHash.Hex(),
 		Quantity:        o.Quantity.String(),
 		Price:           o.Price.String(),
 		Nonce:           o.Nonce.String(),
@@ -56,6 +57,7 @@ func (o *OrderItem) SetBSON(raw bson.Raw) error {
 		Side            string           `json:"side" bson:"side"`
 		Type            string           `json:"type" bson:"type"`
 		Hash            string           `json:"hash" bson:"hash"`
+		TxHash          string           `json:"txHash" bson:"hash"`
 		Price           string           `json:"price" bson:"price"`
 		Quantity        string           `json:"quantity" bson:"quantity"`
 		FilledAmount    string           `json:"filledAmount" bson:"filledAmount"`
@@ -85,7 +87,7 @@ func (o *OrderItem) SetBSON(raw bson.Raw) error {
 	o.Side = decoded.Side
 	o.Type = decoded.Type
 	o.Hash = common.HexToHash(decoded.Hash)
-
+	o.TxHash = common.HexToHash(decoded.TxHash)
 	if decoded.Quantity != "" {
 		o.Quantity = ToBigInt(decoded.Quantity)
 	}

--- a/tomox/order.go
+++ b/tomox/order.go
@@ -109,8 +109,15 @@ func (order *Order) GetPrevOrder(orderList *OrderList, dryrun bool, blockHash co
 // NewOrder : create new order with quote ( can be ethereum address )
 func NewOrder(orderItem *OrderItem, orderListKey []byte) *Order {
 	key := GetKeyFromBig(new(big.Int).SetUint64(orderItem.OrderID))
-	orderItem.NextOrder = EmptyKey()
-	orderItem.PrevOrder = EmptyKey()
+	// if PrevOrder, NextOrder are already set, keep them
+	// when order is loaded from snapshot, they should be set
+	// we should not reset to emptyKey in order not to break this link list
+	if orderItem.NextOrder == nil {
+		orderItem.NextOrder = EmptyKey()
+	}
+	if orderItem.PrevOrder == nil {
+		orderItem.PrevOrder = EmptyKey()
+	}
 	orderItem.OrderList = orderListKey
 	// key should be Hash for compatible with smart contract
 	order := &Order{

--- a/tomox/order.go
+++ b/tomox/order.go
@@ -43,6 +43,7 @@ type OrderItem struct {
 	Side            string         `json:"side,omitempty"`
 	Type            string         `json:"type,omitempty"`
 	Hash            common.Hash    `json:"hash,omitempty"`
+	TxHash          common.Hash    `json:"txHash,omitempty"`
 	Signature       *Signature     `json:"signature,omitempty"`
 	FilledAmount    *big.Int       `json:"filledAmount,omitempty"`
 	Nonce           *big.Int       `json:"nonce,omitempty"`
@@ -68,6 +69,7 @@ type OrderItemBSON struct {
 	Side            string           `json:"side,omitempty" bson:"side"`
 	Type            string           `json:"type,omitempty" bson:"type"`
 	Hash            string           `json:"hash,omitempty" bson:"hash"`
+	TxHash          string           `json:"txHash,omitempty" bson:"txHash"`
 	Signature       *SignatureRecord `json:"signature,omitempty" bson:"signature"`
 	FilledAmount    string           `json:"filledAmount,omitempty" bson:"filledAmount"`
 	Nonce           string           `json:"nonce,omitempty" bson:"nonce"`

--- a/tomox/orderbook.go
+++ b/tomox/orderbook.go
@@ -381,7 +381,7 @@ func (orderBook *OrderBook) processOrderList(side string, orderList *OrderList, 
 		if headOrder == nil {
 			return nil, nil, nil, fmt.Errorf("headOrder is null")
 		}
-		log.Debug("Get head order in the orderlist", "headOrder", headOrder.Item)
+		log.Debug("Get head order in the orderlist", "headOrder", headOrder, "prev", headOrder.Item.PrevOrder, "next", headOrder.Item.NextOrder)
 
 		tradedPrice := CloneBigInt(headOrder.Item.Price)
 

--- a/tomox/orderbook.go
+++ b/tomox/orderbook.go
@@ -530,7 +530,7 @@ func (orderBook *OrderBook) VolumeAtPrice(side string, price *big.Int, dryrun bo
 }
 
 func (orderBook *OrderBook) Hash() (common.Hash, error) {
-	obEncoded, err := EncodeBytesItem(orderBook.Item)
+	obEncoded, err := EncodeBytesItem(*orderBook.Item)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/tomox/orderlist.go
+++ b/tomox/orderlist.go
@@ -190,7 +190,7 @@ func (orderList *OrderList) OrderExist(key []byte, dryrun bool, blockHash common
 
 func (orderList *OrderList) SaveOrder(order *Order, dryrun bool, blockHash common.Hash) error {
 	key := orderList.GetOrderID(order)
-	log.Debug("Save order ", "key", hex.EncodeToString(key), "value", ToJSON(order.Item))
+	log.Debug("Save order ", "key", hex.EncodeToString(key), "value", order.Item)
 
 	return orderList.orderTree.orderDB.Put(key, order.Item, dryrun, blockHash)
 }

--- a/tomox/orderlist.go
+++ b/tomox/orderlist.go
@@ -248,9 +248,7 @@ func (orderList *OrderList) RemoveOrder(order *Order, dryrun bool, blockHash com
 	}
 
 	nextOrder := orderList.GetOrder(order.Item.NextOrder, dryrun, blockHash)
-	log.Debug("Orderlist remove order debug", "nextOrder", nextOrder)
 	prevOrder := orderList.GetOrder(order.Item.PrevOrder, dryrun, blockHash)
-	log.Debug("Orderlist remove order debug", "prevOrder", prevOrder)
 
 	orderList.Item.Volume = Sub(orderList.Item.Volume, order.Item.Quantity)
 	orderList.Item.Length--

--- a/tomox/orderlist.go
+++ b/tomox/orderlist.go
@@ -79,7 +79,7 @@ func NewOrderListWithItem(item *OrderListItem, orderTree *OrderTree) *OrderList 
 
 func (orderList *OrderList) GetOrder(key []byte, dryrun bool, blockHash common.Hash) *Order {
 	storedKey := orderList.GetOrderIDFromKey(key)
-	log.Debug("Get order from key", "storedKey", hex.EncodeToString(storedKey))
+	//log.Debug("Get order from key", "storedKey", hex.EncodeToString(storedKey))
 	return orderList.orderTree.orderBook.GetOrder(storedKey, key, dryrun, blockHash)
 }
 

--- a/tomox/orderlist.go
+++ b/tomox/orderlist.go
@@ -242,14 +242,15 @@ func (orderList *OrderList) RemoveOrder(order *Order, dryrun bool, blockHash com
 		return nil
 	}
 
-	//remove order from DB
-	if err := orderList.DeleteOrder(order, dryrun, blockHash); err != nil {
-		return err
-	}
 
 	nextOrder := orderList.GetOrder(order.Item.NextOrder, dryrun, blockHash)
 	prevOrder := orderList.GetOrder(order.Item.PrevOrder, dryrun, blockHash)
 
+	//remove order from DB
+	if err := orderList.DeleteOrder(order, dryrun, blockHash); err != nil {
+		return err
+	}
+	
 	orderList.Item.Volume = Sub(orderList.Item.Volume, order.Item.Quantity)
 	orderList.Item.Length--
 

--- a/tomox/ordertree.go
+++ b/tomox/ordertree.go
@@ -444,8 +444,20 @@ func (orderTree *OrderTree) MinPriceList(dryrun bool, blockHash common.Hash) *Or
 	return nil
 }
 
-func (orderTree *OrderTree) Hash() (common.Hash, error) {
-	olEncoded, err := EncodeBytesItem(orderTree.Item)
+func (orderTree *OrderTree) Hash(dryrun bool, blockhash common.Hash) (common.Hash, error) {
+	allPriceKeys := orderTree.PriceTree.Keys(dryrun, blockhash)
+
+	olEncoded, err := EncodeBytesItem(struct {
+		Volume        []byte
+		NumOrders     uint64
+		PriceTreeSize uint64
+		AllPriceKeys  [][]byte
+	}{
+		orderTree.Item.Volume.Bytes(),
+		orderTree.Item.NumOrders,
+		orderTree.Item.PriceTreeSize,
+		allPriceKeys,
+	})
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/tomox/ordertree.go
+++ b/tomox/ordertree.go
@@ -226,8 +226,11 @@ func (orderTree *OrderTree) OrderExist(key []byte, price *big.Int, dryrun bool, 
 }
 
 func (orderTree *OrderTree) InsertOrder(order *OrderItem, dryrun bool, blockHash common.Hash) error {
-
 	price := order.Price
+	if orderTree.OrderExist(GetKeyFromBig(new(big.Int).SetUint64(order.OrderID)), price, dryrun, blockHash) {
+		log.Warn("order already existed", "order", order)
+		return nil
+	}
 
 	var orderList *OrderList
 
@@ -243,13 +246,6 @@ func (orderTree *OrderTree) InsertOrder(order *OrderItem, dryrun bool, blockHash
 	if orderList != nil {
 
 		order := NewOrder(order, GetOrderListCommonKey(orderList.Key, orderTree.orderBook.Item.Name))
-
-		if orderList.OrderExist(order.Key, dryrun, blockHash) {
-			if err := orderTree.RemoveOrder(order, dryrun, blockHash); err != nil {
-				return err
-			}
-		}
-
 		// append order to order list
 		log.Debug("debug orderlist", "before", orderList.Item)
 		if err := orderList.AppendOrder(order, dryrun, blockHash); err != nil {

--- a/tomox/redblacktree.go
+++ b/tomox/redblacktree.go
@@ -65,7 +65,7 @@ func (tree *Tree) Put(key []byte, value []byte, dryrun bool, blockHash common.Ha
 	if tree.IsEmptyKey(tree.rootKey) {
 		// Assert key is of comparator's type for initial tree
 		item := &Item{Value: value, Color: red, Keys: &KeyMeta{}}
-		log.Debug("RootKey hasn't been set. Set it now", "rootkey", hex.EncodeToString(key), "all keys", tree.KeysinString(true, blockHash))
+		//log.Debug("RootKey hasn't been set. Set it now", "rootkey", hex.EncodeToString(key), "all keys", tree.KeysinString(true, blockHash))
 		tree.rootKey = key
 		insertedNode = &Node{Key: key, Item: item}
 	} else {
@@ -113,7 +113,7 @@ func (tree *Tree) Put(key []byte, value []byte, dryrun bool, blockHash common.Ha
 	}
 
 	tree.insertCase1(insertedNode, dryrun, blockHash)
-	log.Debug("Put node", "insertedNode key", hex.EncodeToString(insertedNode.Key), "all keys", tree.KeysinString(true, blockHash))
+	//log.Debug("Put node", "insertedNode key", hex.EncodeToString(insertedNode.Key), "all keys", tree.KeysinString(true, blockHash))
 	tree.Save(insertedNode, dryrun, blockHash)
 
 	tree.size++
@@ -188,11 +188,11 @@ func (tree *Tree) Remove(key []byte, dryrun bool, blockHash common.Hash) {
 			if parent != nil {
 				if !tree.IsEmptyKey(parent.LeftKey()) && bytes.Equal(parent.LeftKey(), node.Key) {
 					parent.Item.Keys.Left = EmptyKey()
-					log.Debug("Set parent.LeftKey() to nil", "parent.Key", parent.Item.Keys)
+					//log.Debug("Set parent.LeftKey() to nil", "parent.Key", parent.Item.Keys)
 					tree.Save(parent, dryrun, blockHash)
 				} else if !tree.IsEmptyKey(parent.RightKey()) && bytes.Equal(parent.RightKey(), node.Key) {
 					parent.Item.Keys.Right = EmptyKey()
-					log.Debug("Set parent.RightKey() to nil", "parent.Key", parent.Item.Keys)
+					//log.Debug("Set parent.RightKey() to nil", "parent.Key", parent.Item.Keys)
 					tree.Save(parent, dryrun, blockHash)
 				} else {
 					log.Error("Parent doesn't have node as child", "node.Key", hex.EncodeToString(node.Key))
@@ -203,7 +203,7 @@ func (tree *Tree) Remove(key []byte, dryrun bool, blockHash common.Hash) {
 				tree.rootKey = EmptyKey()
 			}
 			tree.deleteNode(node, dryrun, blockHash)
-			log.Debug("Removed node with child = nil", "node", hex.EncodeToString(node.Key), "all keys", tree.KeysinString(true, blockHash))
+			//log.Debug("Removed node with child = nil", "node", hex.EncodeToString(node.Key), "all keys", tree.KeysinString(true, blockHash))
 		} else {
 			if node.Item.Color == black {
 				node.Item.Color = nodeColor(child)
@@ -222,7 +222,7 @@ func (tree *Tree) Remove(key []byte, dryrun bool, blockHash common.Hash) {
 	}
 
 	tree.size--
-	log.Debug("Deleted node", "node key", hex.EncodeToString(node.Key), "all keys", tree.KeysinString(true, blockHash), "tree.size", tree.size)
+	//log.Debug("Deleted node", "node key", hex.EncodeToString(node.Key), "all keys", tree.KeysinString(true, blockHash), "tree.size", tree.size)
 }
 
 // // Empty returns true if tree does not contain any nodes
@@ -402,7 +402,7 @@ func output(tree *Tree, node *Node, prefix string, isTail bool, str *string, dry
 }
 
 func (tree *Tree) rotateLeft(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Rotate left - before", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
+	//log.Debug("Rotate left - before", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
 	right := node.Right(tree, dryrun, blockHash)
 	tree.replaceNode(node, right, dryrun, blockHash)
 	node.RightKey(right.LeftKey())
@@ -415,11 +415,11 @@ func (tree *Tree) rotateLeft(node *Node, dryrun bool, blockHash common.Hash) {
 	node.ParentKey(right.Key)
 	tree.Save(node, dryrun, blockHash)
 	tree.Save(right, dryrun, blockHash)
-	log.Debug("Rotate left - after", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
+	//log.Debug("Rotate left - after", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
 }
 
 func (tree *Tree) rotateRight(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Rotate right - before", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
+	//log.Debug("Rotate right - before", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
 	left := node.Left(tree, dryrun, blockHash)
 	tree.replaceNode(node, left, dryrun, blockHash)
 	node.LeftKey(left.RightKey())
@@ -432,11 +432,11 @@ func (tree *Tree) rotateRight(node *Node, dryrun bool, blockHash common.Hash) {
 	node.ParentKey(left.Key)
 	tree.Save(node, dryrun, blockHash)
 	tree.Save(left, dryrun, blockHash)
-	log.Debug("Rotate right - after", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
+	//log.Debug("Rotate right - after", "Root key", hex.EncodeToString(tree.Root(dryrun, blockHash).Key), "all keys", tree.KeysinString(true, blockHash))
 }
 
 func (tree *Tree) replaceNode(old *Node, new *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Replace node", "old", old, "new", new)
+	//log.Debug("Replace node", "old", old, "new", new)
 
 	// we do not change any byte of Key so we can copy the reference to save directly to db
 	var newKey []byte
@@ -447,7 +447,7 @@ func (tree *Tree) replaceNode(old *Node, new *Node, dryrun bool, blockHash commo
 	}
 
 	if tree.IsEmptyKey(old.ParentKey()) {
-		log.Debug("Set root key - replaceNode", "key", hex.EncodeToString(newKey), "size", tree.size, "all keys", tree.KeysinString(true, blockHash))
+		//log.Debug("Set root key - replaceNode", "key", hex.EncodeToString(newKey), "size", tree.size, "all keys", tree.KeysinString(true, blockHash))
 		tree.rootKey = newKey
 	} else {
 		// update left and right for oldParent
@@ -473,7 +473,7 @@ func (tree *Tree) replaceNode(old *Node, new *Node, dryrun bool, blockHash commo
 }
 
 func (tree *Tree) insertCase1(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Insert case 1", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Insert case 1", "node key", hex.EncodeToString(node.Key))
 	if tree.IsEmptyKey(node.ParentKey()) {
 		node.Item.Color = black
 	} else {
@@ -482,7 +482,7 @@ func (tree *Tree) insertCase1(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) insertCase2(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Insert case 2", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Insert case 2", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	if nodeColor(parent) == black {
 		return
@@ -492,7 +492,7 @@ func (tree *Tree) insertCase2(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) insertCase3(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Insert case 3", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Insert case 3", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	uncle := node.uncle(tree, dryrun, blockHash)
 	if nodeColor(uncle) == red {
@@ -512,7 +512,7 @@ func (tree *Tree) insertCase3(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) insertCase4(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Insert case 4", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Insert case 4", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	grandparent := parent.Parent(tree, dryrun, blockHash)
 	tree.assertNotNull(grandparent, "grant parent")
@@ -536,7 +536,7 @@ func (tree *Tree) assertNotNull(node *Node, name string) {
 }
 
 func (tree *Tree) insertCase5(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Insert case 5", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Insert case 5", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	parent.Item.Color = black
 	tree.Save(parent, dryrun, blockHash)
@@ -557,12 +557,12 @@ func (tree *Tree) insertCase5(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) Save(node *Node, dryrun bool, blockHash common.Hash) error {
-	log.Debug("Save node", "node", node, "key", hex.EncodeToString(node.Key))
+	//log.Debug("Save node", "node", node, "key", hex.EncodeToString(node.Key))
 	return tree.db.Put(node.Key, node.Item, dryrun, blockHash)
 }
 
 func (tree *Tree) deleteCase1(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 1", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 1", "node key", hex.EncodeToString(node.Key))
 	if tree.IsEmptyKey(node.ParentKey()) {
 		//tree.deleteNode(node, dryrun, blockHash)
 		return
@@ -572,7 +572,7 @@ func (tree *Tree) deleteCase1(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) deleteCase2(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 2", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 2", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	sibling := node.sibling(tree, dryrun, blockHash)
 
@@ -592,7 +592,7 @@ func (tree *Tree) deleteCase2(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) deleteCase3(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 3", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 3", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	sibling := node.sibling(tree, dryrun, blockHash)
 	siblingLeft := sibling.Left(tree, dryrun, blockHash)
@@ -613,7 +613,7 @@ func (tree *Tree) deleteCase3(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) deleteCase4(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 4", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 4", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	sibling := node.sibling(tree, dryrun, blockHash)
 	siblingLeft := sibling.Left(tree, dryrun, blockHash)
@@ -633,7 +633,7 @@ func (tree *Tree) deleteCase4(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) deleteCase5(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 5", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 5", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	sibling := node.sibling(tree, dryrun, blockHash)
 	siblingLeft := sibling.Left(tree, dryrun, blockHash)
@@ -669,7 +669,7 @@ func (tree *Tree) deleteCase5(node *Node, dryrun bool, blockHash common.Hash) {
 }
 
 func (tree *Tree) deleteCase6(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("delete case 6", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("delete case 6", "node key", hex.EncodeToString(node.Key))
 	parent := node.Parent(tree, dryrun, blockHash)
 	sibling := node.sibling(tree, dryrun, blockHash)
 	siblingLeft := sibling.Left(tree, dryrun, blockHash)
@@ -703,6 +703,6 @@ func nodeColor(node *Node) bool {
 }
 
 func (tree *Tree) deleteNode(node *Node, dryrun bool, blockHash common.Hash) {
-	log.Debug("Delete node", "node key", hex.EncodeToString(node.Key))
+	//log.Debug("Delete node", "node key", hex.EncodeToString(node.Key))
 	tree.db.Delete(node.Key, dryrun, blockHash)
 }

--- a/tomox/relayer_state.go
+++ b/tomox/relayer_state.go
@@ -1,12 +1,12 @@
 package tomox
 
 import (
+	"github.com/ethereum/go-ethereum/log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
 )
 
@@ -75,14 +75,14 @@ func SubRelayerFee(relayer common.Address, fee *big.Int, statedb *state.StateDB)
 	locBigDeposit := new(big.Int).SetUint64(uint64(0)).Add(locBig, RelayerStructMappingSlot["_deposit"])
 	locHashDeposit := common.BigToHash(locBigDeposit)
 	balance := statedb.GetState(common.HexToAddress(common.RelayerRegistrationSMC), locHashDeposit).Big()
-	log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer.String(), "balance", balance)
+	//log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee BEFORE", "relayer", relayer.String(), "balance", balance)
 	if balance.Cmp(fee) < 0 {
 		return errors.Errorf("relayer %s isn't enough tomo fee", relayer.String())
 	} else {
 		balance = balance.Sub(balance, fee)
 		statedb.SetState(common.HexToAddress(common.RelayerRegistrationSMC), locHashDeposit, common.BigToHash(balance))
 		statedb.SubBalance(common.HexToAddress(common.RelayerRegistrationSMC), fee)
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer.String(), "balance", balance)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: SubRelayerFee AFTER", "relayer", relayer.String(), "balance", balance)
 		return nil
 	}
 }
@@ -91,10 +91,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	// TOMO native
 	if token.String() == common.TomoNativeAddress {
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN TOMO NATIVE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN TOMO NATIVE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		balance = balance.Add(balance, value)
 		statedb.SetBalance(addr, balance)
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance , "orderValue", value)
 
 		return nil
 	}
@@ -104,10 +104,10 @@ func AddTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(getLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		balance = balance.Add(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: ADD TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance , "orderValue", value)
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())
@@ -119,13 +119,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 	if token.String() == common.TomoNativeAddress {
 
 		balance := statedb.GetBalance(addr)
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		balance = balance.Sub(balance, value)
 		statedb.SetBalance(addr, balance)
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOMO NATIVE BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		return nil
 	}
 
@@ -134,13 +134,13 @@ func SubTokenBalance(addr common.Address, value *big.Int, token common.Address, 
 		slot := TokenMappingSlot["balances"]
 		locHash := common.BigToHash(getLocMappingAtKey(addr.Hash(), slot))
 		balance := statedb.GetState(token, locHash).Big()
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE BEFORE", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		if balance.Cmp(value) < 0 {
 			return errors.Errorf("value %s in token %s not enough , have : %s , want : %s  ", addr.String(), token.String(), balance, value)
 		}
 		balance = balance.Sub(balance, value)
 		statedb.SetState(token, locHash, common.BigToHash(balance))
-		log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value)
+		//log.Debug("ApplyTomoXMatchedTransaction settle balance: SUB TOKEN BALANCE AFTER", "token", token.String(), "address", addr.String(), "balance", balance, "orderValue", value )
 		return nil
 	} else {
 		return errors.Errorf("token %s isn't exist", token.String())

--- a/tomox/snapshot.go
+++ b/tomox/snapshot.go
@@ -3,10 +3,11 @@ package tomox
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"math/big"
 )
 
 const (
@@ -280,9 +281,6 @@ func (s *Snapshot) RestoreOrderTree(treeSnap *OrderTreeSnapshot, tree *OrderTree
 		return tree, err
 	}
 	return tree, nil
-}
-func GetNearestSnapshotBlock(blockNum uint64) uint64 {
-	return blockNum - (blockNum % SnapshotInterval)
 }
 
 func (tomox *TomoX) ApplyDryrunCache(blockHash common.Hash) error {

--- a/tomox/snapshot.go
+++ b/tomox/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"math/big"
 )
 
@@ -279,4 +280,16 @@ func (s *Snapshot) RestoreOrderTree(treeSnap *OrderTreeSnapshot, tree *OrderTree
 		return tree, err
 	}
 	return tree, nil
+}
+func GetNearestSnapshotBlock(blockNum uint64) uint64 {
+	return blockNum - (blockNum % SnapshotInterval)
+}
+
+func (tomox *TomoX) ApplyDryrunCache(blockHash common.Hash) error {
+	log.Debug("Apply dryrunCache to snapshot", "blockhash", blockHash)
+	if err := tomox.db.SaveDryRunResult(blockHash); err != nil {
+		log.Error("Failed to save dry-run result to snapshot", "err", err)
+		return err
+	}
+	return nil
 }

--- a/tomox/snapshot.go
+++ b/tomox/snapshot.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
@@ -281,13 +280,4 @@ func (s *Snapshot) RestoreOrderTree(treeSnap *OrderTreeSnapshot, tree *OrderTree
 		return tree, err
 	}
 	return tree, nil
-}
-
-func (tomox *TomoX) ApplyDryrunCache(blockHash common.Hash) error {
-	log.Debug("Apply dryrunCache to snapshot", "blockhash", blockHash)
-	if err := tomox.db.SaveDryRunResult(blockHash); err != nil {
-		log.Error("Failed to save dry-run result to snapshot", "err", err)
-		return err
-	}
-	return nil
 }

--- a/tomox/snapshot_test.go
+++ b/tomox/snapshot_test.go
@@ -2,6 +2,7 @@ package tomox
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"math/rand"
 	"os"
@@ -154,7 +155,7 @@ func TestTomoX_Snapshot(t *testing.T) {
 		}),
 	}
 	defer os.RemoveAll(testDir)
-	blockHash := common.StringToHash("aaa")
+	block := types.NewBlock(&types.Header{}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{})
 	pair := "aaa/tomo"
 
 	// orderbooks["aaa/tomo"] has 2 bids orders and 2 asks orders
@@ -170,8 +171,8 @@ func TestTomoX_Snapshot(t *testing.T) {
 		t.Error(err)
 	}
 	tomox.activePairs[pair] = true
-	if err := tomox.Snapshot(blockHash); err != nil {
-		t.Error("Failed to store snapshot", "err", err, "blockHash", blockHash)
+	if err := tomox.Snapshot(block); err != nil {
+		t.Error("Failed to store snapshot", "err", err, "block", block)
 	}
 
 
@@ -197,14 +198,14 @@ func TestTomoX_Snapshot(t *testing.T) {
 		t.Error("Expected an error due to wrong hash")
 	}
 
-	newSnap, err = getSnapshot(tomox.db, blockHash)
+	newSnap, err = getSnapshot(tomox.db, block.Hash())
 	if err != nil {
 		t.Error("Failed to load snapshot", err)
 	}
 
 	// verify snapshot hash
-	if newSnap.Hash != blockHash {
-		t.Error("Wrong snapshot hash", "expected", blockHash, "actual", newSnap.Hash)
+	if newSnap.Hash != block.Hash() {
+		t.Error("Wrong snapshot hash", "expected", block, "actual", newSnap.Hash)
 	}
 
 	// load orderbook of an invalid pair

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"encoding/hex"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -891,25 +890,25 @@ func (tomox *TomoX) ProcessOrderPending(pending map[common.Address]types.OrderTr
 				continue
 			}
 
-			log.Info("Process order pending", "orderPending", order)
-			obOld, err := ob.Hash()
-			if err != nil {
-				log.Error("Fail to get orderbook hash old", "err", err)
-				continue
-			}
-			askOld, err := ob.Asks.Hash()
-			if err != nil {
-				log.Error("Fail to get ask tree hash old", "err", err)
-				continue
-			}
-			bidOld, err := ob.Bids.Hash()
-			if err != nil {
-				log.Error("Fail to get bid tree hash old", "err", err)
-				continue
-			}
-			originalOrder := &OrderItem{}
-			*originalOrder = *order
-			originalOrder.Quantity = CloneBigInt(order.Quantity)
+						log.Info("Process order pending", "orderPending", order)
+						obOld, err := ob.Hash()
+						if err != nil {
+							log.Error("Fail to get orderbook hash old", "err", err)
+							continue
+						}
+						askOld, err := ob.Asks.Hash(true, blockHash)
+						if err != nil {
+							log.Error("Fail to get ask tree hash old", "err", err)
+							continue
+						}
+						bidOld, err := ob.Bids.Hash(true, blockHash)
+						if err != nil {
+							log.Error("Fail to get bid tree hash old", "err", err)
+							continue
+						}
+						originalOrder := &OrderItem{}
+						*originalOrder = *order
+						originalOrder.Quantity = CloneBigInt(order.Quantity)
 
 			if cancel {
 				order.Status = OrderStatusCancelled
@@ -917,25 +916,25 @@ func (tomox *TomoX) ProcessOrderPending(pending map[common.Address]types.OrderTr
 
 			trades, _, err := ob.ProcessOrder(order, true, true, blockHash)
 
-			if err != nil {
-				log.Error("Can't process order", "order", order, "err", err)
-				continue
-			}
-			obNew, err := ob.Hash()
-			if err != nil {
-				log.Error("Fail to get orderbook hash new", "err", err)
-				continue
-			}
-			askNew, err := ob.Asks.Hash()
-			if err != nil {
-				log.Error("Fail to get ask tree hash new", "err", err)
-				continue
-			}
-			bidNew, err := ob.Bids.Hash()
-			if err != nil {
-				log.Error("Fail to get bid tree hash new", "err", err)
-				continue
-			}
+						if err != nil {
+							log.Error("Can't process order", "order", order, "err", err)
+							continue
+						}
+						obNew, err := ob.Hash()
+						if err != nil {
+							log.Error("Fail to get orderbook hash new", "err", err)
+							continue
+						}
+						askNew, err := ob.Asks.Hash(true, blockHash)
+						if err != nil {
+							log.Error("Fail to get ask tree hash new", "err", err)
+							continue
+						}
+						bidNew, err := ob.Bids.Hash(true, blockHash)
+						if err != nil {
+							log.Error("Fail to get bid tree hash new", "err", err)
+							continue
+						}
 
 			// orderID has been updated
 			originalOrder.OrderID = order.OrderID
@@ -1213,7 +1212,7 @@ func (tomox *TomoX) LoadSnapshot(hash common.Hash) error {
 		return err
 	}
 	for pair := range snap.OrderBooks {
-		ob, err = snap.RestoreOrderBookFromSnapshot(tomox.db, pair)
+		ob, err = snap.RestoreOrderBookFromSnapshot(tomox.db, pair, false, common.Hash{})
 		if err == nil {
 			if err := ob.Save(false, common.Hash{}); err != nil {
 				return err
@@ -1235,7 +1234,6 @@ func (tomox *TomoX) ApplyTxMatches(orders []*OrderItem, blockHash common.Hash) e
 		if err := tomox.UpdateOrderNonce(order.UserAddress, order.Nonce); err != nil {
 			log.Error("Update orderNonce via ApplyTxMatches failed", "err", err)
 		}
-
 	}
 	return nil
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -836,7 +836,7 @@ func (tomox *TomoX) GetAsksTree(pairName string, dryrun bool, blockHash common.H
 }
 
 func (tomox *TomoX) ProcessOrderPending(pending map[common.Address]types.OrderTransactions) []TxDataMatch {
-	blockHash := common.StringToHash("COMMIT_NEW_WORK" + time.Now().String())
+	blockHash := common.StringToHash("COMMIT_NEW_WORK")
 	txMatches := []TxDataMatch{}
 	tomox.db.InitDryRunMode(blockHash)
 
@@ -915,16 +915,6 @@ func (tomox *TomoX) ProcessOrderPending(pending map[common.Address]types.OrderTr
 			}
 
 			trades, _, err := ob.ProcessOrder(order, true, true, blockHash)
-
-			// remove order from pending list
-			if err := tomox.RemoveOrderFromPending(order.Hash, order.Status == OrderStatusCancelled); err != nil {
-				continue
-			}
-
-			// remove order pending
-			if err := tomox.RemoveOrderPendingFromDB(order.Hash, order.Status == OrderStatusCancelled); err != nil {
-				continue
-			}
 
 			if err != nil {
 				log.Error("Can't process order", "order", order, "err", err)
@@ -1126,7 +1116,7 @@ func (tomox *TomoX) ExistProcessedOrderHash(orderHash common.Hash, blockhash com
 	}
 	bh, ok := tomox.processedOrderCache.Get(orderHash)
 	if ok && bh == blockhash {
-		return  true
+		return true
 	}
 	return false
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1345,18 +1345,13 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 
 func (tomox *TomoX) updateMatchedOrder(hashString string, filledAmount *big.Int) error {
 	db := tomox.GetDB()
-	orderHashBytes, err := hex.DecodeString(hashString)
-	if err != nil {
-		return fmt.Errorf("SDKNode: failed to decode orderKey. Key: %s", hashString)
-	}
-	val, err := db.Get(orderHashBytes, &OrderItem{}, false, common.Hash{})
+	orderHash := common.HexToHash(hashString)
+	val, err := db.Get(orderHash.Bytes(), &OrderItem{}, false, common.Hash{})
 	if err != nil || val == nil {
 		return fmt.Errorf("SDKNode: failed to get order. Key: %s", hashString)
 	}
 	matchedOrder := val.(*OrderItem)
-	updatedFillAmount := new(big.Int)
-	updatedFillAmount.Add(matchedOrder.FilledAmount, filledAmount)
-	matchedOrder.FilledAmount = updatedFillAmount
+	matchedOrder.FilledAmount.Add(matchedOrder.FilledAmount, filledAmount)
 	if matchedOrder.FilledAmount.Cmp(matchedOrder.Quantity) < 0 {
 		matchedOrder.Status = OrderStatusPartialFilled
 	} else {

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1286,6 +1286,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	if order.Status != OrderStatusCancelled {
 		order.Status = OrderStatusOpen
 	}
+	order.TxHash = txHash
 
 	log.Debug("Put processed order", "order", order)
 	if err := db.Put(order.Hash.Bytes(), order, false, common.Hash{}); err != nil {

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1095,20 +1095,17 @@ func (tomox *TomoX) getPendingOrders() []OrderPending {
 }
 
 func (tomox *TomoX) addProcessedOrderHash(orderHash common.Hash, cancel bool, blockhash common.Hash) error {
-	if !tomox.processedOrderCache.Add(orderHash, blockhash) {
-		// remove order from pending list
-		if err := tomox.RemoveOrderFromPending(orderHash, cancel); err != nil {
-			log.Warn("Double check pending order at addProcessedOrderHash. Failed to remove pending hash", "err", err, "orderHash", orderHash)
-		}
-
-		// remove order pending
-		if err := tomox.RemoveOrderPendingFromDB(orderHash, cancel); err != nil {
-			log.Warn("Double check pending order at addProcessedOrderHash. Failed to remove pending order", "err", err, "orderHash", orderHash)
-		}
-		return nil
-	} else {
-		return fmt.Errorf("Can't add processed order to cache: orderHash - %s", orderHash.Hex())
+	tomox.processedOrderCache.Add(orderHash, blockhash)
+	// remove order from pending list
+	if err := tomox.RemoveOrderFromPending(orderHash, cancel); err != nil {
+		log.Warn("Double check pending order at addProcessedOrderHash. Failed to remove pending hash", "err", err, "orderHash", orderHash)
 	}
+
+	// remove order pending
+	if err := tomox.RemoveOrderPendingFromDB(orderHash, cancel); err != nil {
+		log.Warn("Double check pending order at addProcessedOrderHash. Failed to remove pending order", "err", err, "orderHash", orderHash)
+	}
+	return nil
 }
 
 func (tomox *TomoX) ExistProcessedOrderHash(orderHash common.Hash, blockhash common.Hash) bool {

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1189,10 +1189,6 @@ func (tomox *TomoX) Snapshot(block *types.Block) error {
 	if err = snap.store(tomox.db); err != nil {
 		return err
 	}
-	tomox.db.InitDryRunMode(block.HashNoValidator(), common.Hash{})
-	if err = tomox.db.Put([]byte(latestSnapshotKey), &blockHash, true, block.HashNoValidator()); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -1274,7 +1270,6 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 
 	// 1. put processed order to db
 	if order, err = txDataMatch.DecodeOrder(); err != nil {
-		log.Error("SDK node decode order failed", "txDataMatch", txDataMatch)
 		return fmt.Errorf("SDK node decode order failed")
 	}
 

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -1241,7 +1241,7 @@ func (tomox *TomoX) LoadSnapshot(hash common.Hash) error {
 func (tomox *TomoX) ApplyTxMatches(orders []*OrderItem, blockHash common.Hash) error {
 	if !tomox.IsSDKNode() {
 		if err := tomox.db.SaveDryRunResult(blockHash); err != nil {
-			log.Error("Failed to save dry-run result")
+			log.Error("Failed to save dry-run result", "err", err)
 			return err
 		}
 	}

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -54,6 +54,8 @@ const (
 	pendingCancelPrefix  = "XPCANCEL"
 	orderProcessedLimit  = 1000
 	orderProcessLimit    = 20
+	SnapshotInterval     = 1 // 1 block
+
 )
 
 type Config struct {
@@ -190,12 +192,6 @@ func New(cfg *Config) *TomoX {
 			}
 		},
 	}
-	if !tomoX.sdkNode {
-		if err := tomoX.loadSnapshot(common.Hash{}); err != nil {
-			log.Error("Failed to load tomox snapshot", "err", err)
-		}
-	}
-
 	return tomoX
 }
 
@@ -1202,7 +1198,7 @@ func (tomox *TomoX) Snapshot(blockHash common.Hash) error {
 	return nil
 }
 
-func (tomox *TomoX) loadSnapshot(hash common.Hash) error {
+func (tomox *TomoX) LoadSnapshot(hash common.Hash) error {
 	// load orderbook from snapshot
 	var (
 		snap *Snapshot

--- a/tomox/trade.go
+++ b/tomox/trade.go
@@ -25,7 +25,6 @@ const (
 )
 
 type Trade struct {
-	ID             bson.ObjectId  `json:"id,omitempty" bson:"_id"`
 	Taker          common.Address `json:"taker" bson:"taker"`
 	Maker          common.Address `json:"maker" bson:"maker"`
 	BaseToken      common.Address `json:"baseToken" bson:"baseToken"`
@@ -48,7 +47,6 @@ type Trade struct {
 }
 
 type TradeBSON struct {
-	ID             bson.ObjectId `json:"id" bson:"_id"`
 	Taker          string        `json:"taker" bson:"taker"`
 	Maker          string        `json:"maker" bson:"maker"`
 	BaseToken      string        `json:"baseToken" bson:"baseToken"`
@@ -72,7 +70,6 @@ type TradeBSON struct {
 
 func (t *Trade) GetBSON() (interface{}, error) {
 	tr := TradeBSON{
-		ID:             t.ID,
 		PairName:       t.PairName,
 		Maker:          t.Maker.Hex(),
 		Taker:          t.Taker.Hex(),
@@ -105,7 +102,6 @@ func (t *Trade) SetBSON(raw bson.Raw) error {
 		return err
 	}
 
-	t.ID = decoded.ID
 	t.PairName = decoded.PairName
 	t.Taker = common.HexToAddress(decoded.Taker)
 	t.Maker = common.HexToAddress(decoded.Maker)

--- a/tomox/validator.go
+++ b/tomox/validator.go
@@ -186,7 +186,7 @@ func GetTokenBalance(statedb *state.StateDB, address common.Address, contractAdd
 }
 
 // verify orderbook, orderTrees before running matching engine
-func (tx TxDataMatch) VerifyOldTomoXState(ob *OrderBook) error {
+func (tx TxDataMatch) VerifyOldTomoXState(ob *OrderBook, dryrun bool, blockhash common.Hash) error {
 	// verify orderbook
 	if hash, err := ob.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.ObOld.Bytes()) {
 		log.Error("wrong old orderbook", "expected", hex.EncodeToString(tx.ObOld.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
@@ -196,13 +196,13 @@ func (tx TxDataMatch) VerifyOldTomoXState(ob *OrderBook) error {
 	// verify order trees
 	// bidTree tree
 	bidTree := ob.Bids
-	if hash, err := bidTree.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.BidOld.Bytes()) {
+	if hash, err := bidTree.Hash(dryrun, blockhash); err != nil || !bytes.Equal(hash.Bytes(), tx.BidOld.Bytes()) {
 		log.Error("wrong old bid tree", "expected", hex.EncodeToString(tx.BidOld.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
 		return errOrderTreeHashNotMatch
 	}
 	// askTree tree
 	askTree := ob.Asks
-	if hash, err := askTree.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.AskOld.Bytes()) {
+	if hash, err := askTree.Hash(dryrun, blockhash); err != nil || !bytes.Equal(hash.Bytes(), tx.AskOld.Bytes()) {
 		log.Error("wrong old ask tree", "expected", hex.EncodeToString(tx.AskOld.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
 		return errOrderTreeHashNotMatch
 	}
@@ -210,7 +210,7 @@ func (tx TxDataMatch) VerifyOldTomoXState(ob *OrderBook) error {
 }
 
 // verify orderbook, orderTrees after running matching engine
-func (tx TxDataMatch) VerifyNewTomoXState(ob *OrderBook) error {
+func (tx TxDataMatch) VerifyNewTomoXState(ob *OrderBook, dryrun bool, blockhash common.Hash) error {
 	// verify orderbook
 	if hash, err := ob.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.ObNew.Bytes()) {
 		log.Error("wrong new orderbook", "expected", hex.EncodeToString(tx.ObNew.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
@@ -220,13 +220,13 @@ func (tx TxDataMatch) VerifyNewTomoXState(ob *OrderBook) error {
 	// verify order trees
 	// bidTree tree
 	bidTree := ob.Bids
-	if hash, err := bidTree.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.BidNew.Bytes()) {
+	if hash, err := bidTree.Hash(dryrun, blockhash); err != nil || !bytes.Equal(hash.Bytes(), tx.BidNew.Bytes()) {
 		log.Error("wrong new bid tree", "expected", hex.EncodeToString(tx.BidNew.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
 		return errOrderTreeHashNotMatch
 	}
 	// askTree tree
 	askTree := ob.Asks
-	if hash, err := askTree.Hash(); err != nil || !bytes.Equal(hash.Bytes(), tx.AskNew.Bytes()) {
+	if hash, err := askTree.Hash(dryrun, blockhash); err != nil || !bytes.Equal(hash.Bytes(), tx.AskNew.Bytes()) {
 		log.Error("wrong new ask tree", "expected", hex.EncodeToString(tx.AskNew.Bytes()), "actual", hex.EncodeToString(hash.Bytes()), "err", err)
 		return errOrderTreeHashNotMatch
 	}


### PR DESCRIPTION
Changes in this PR:
- Save dryrunCache to DB every SnapshotInterval =100 blocks
- Snapshot tomoxState every SnapshotInterval = 100 blocks
- dryrunCache[block N + 1] = dryrunCache[block N] + tomoxStateChange in block N + 1
- Update ProcessedOrderHash cache as format: orderhash -> blockhash (mark order as processed at blockhash)
- Only remove pending orders if blocks are inserted to chain
- M1 creates new block and generates a dryruncache for running matching engine. It's useless after that. This PR also removes that cache after collecting txMatch
https://github.com/tomochain/tomochain/pull/717/files#diff-a80e0be49c4c88815bda2a997224568eR806
- Fix bug: some keys exist but have nil value which causes some unexpected problem: error at left, head order is null, order lost from orderTree
Commit: https://github.com/tomochain/tomochain/pull/717/commits/fc343db479e5f61e48da5ad5a65ab4933e134830
- Update snapshot: using slice of orderlist instead of map to keep the order (Redblack tree is order of insertion sensitive)
 Commit: https://github.com/tomochain/tomochain/pull/717/commits/3b1ae51a8947bcad6f2e48a2c186f6bb68c9724a
- Update orderTree hash calculation because  Redblack tree is `order of insertion sensitive`
 Commit: https://github.com/tomochain/tomochain/pull/717/commits/e38d0722375bddfbf585f1409fae2c07f3cbfab6
- When reorg happens:
  - LoadSnapshot at commonBlock
  - Apply dryrunCache of blocks which belongs to newChain
  - Remove orders which belongs to deletedTxs
