### PR TITLE
API getCandidates implementation

### DIFF
--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -5500,6 +5500,12 @@ var methods = function () {
       params: 2,
       inputFormatter: [formatters.inputAddressFormatter, formatters.inputEpochNumberFormatter]
     });
+    var getCandidates = new Method({
+        name: 'getCandidates',
+        call: 'eth_getCandidates',
+        params: 1,
+        inputFormatter: [formatters.inputEpochNumberFormatter]
+      });
     return [
         getBalance,
         getStorageAt,
@@ -5508,6 +5514,7 @@ var methods = function () {
         getBlockSigners,
         getStakerROI,
         getBlockFinality,
+        getCandidates,
         getCandidateStatus,
         getUncle,
         getCompilers,


### PR DESCRIPTION
issue: https://github.com/tomochain/tomochain/issues/743
source: https://github.com/tomochain/tomochain/pull/479

add new API, getCandidates which returns a list of candidates including status and capacity
parametter: epochNumber(in hex)

recommend: a fullnode that turn on gcmode flag, `--gcmode "archive"`. This flag will trigger node to store all block state which can return candidate list at in an epoch. Current node stores block states in 5 minutes or 128 blocks:
https://github.com/ethereum/go-ethereum/wiki/Tracing:-Introduction#pruning
api response: 

> {
    "jsonrpc": "2.0",
    "id": 89,
    "result": {
        "candidates": {
            "0x21292d56E2a8De3cC4672dB039AAA27f9190B1f6": {
                "capacity": 5e+22,
                "status": "MASTERNODE"
            },
            "0x2dA72c9c4792E2ba85E2b980Af4c6aa9Afa9F3dF": {
                "capacity": 5e+22,
                "status": "MASTERNODE"
            },
            "0x8C57cEa3173E5A87B3a61d9d1fE6c0D462f5f9b3": {
                "capacity": 5e+22,
                "status": "MASTERNODE"
            },
            "0xA737eDF7365aE52721F0dee268f6659d44766D6d": {
                "capacity": 5e+22,
                "status": "SLASHED"
            },
            "0xDCa46317e657ecf3DB7d9dAABE50f78E55F3738B": {
                "capacity": 5e+22,
                "status": "MASTERNODE"
            }
        },
        "epoch": 34,
        "success": true
    }
}