### PR TITLE
[Tomox] Re-add status and type to computehash

### DIFF
--- a/tomox/tomox_state/orderitem.go
+++ b/tomox/tomox_state/orderitem.go
@@ -251,6 +251,8 @@ func (o *OrderItem) ComputeHash() common.Hash {
 	}
 	sha.Write(common.BigToHash(o.encodedSide()).Bytes())
 	sha.Write(common.BigToHash(o.Nonce).Bytes())
+	sha.Write(common.StringToHash(o.Status).Bytes())
+	sha.Write(common.StringToHash(o.Type).Bytes())
 	return common.BytesToHash(sha.Sum(nil))
 }
 


### PR DESCRIPTION
After merging the pr: https://github.com/tomochain/tomochain/pull/756

checking signature function(ComputeHash) missed 2 fields(status and type)