### PR TITLE
Remove trades from txdata. All nodes use its matching engine result to settle balance

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -105,7 +105,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 	return nil
 }
 
-func (v *BlockValidator) ValidateMatchingOrder(tomoXService *tomox.TomoX, statedb *state.StateDB, tomoxStatedb *tomox_state.TomoXStateDB, txMatchBatch tomox.TxMatchBatch, blockHashNovalidator common.Hash) error {
+func (v *BlockValidator) ValidateMatchingOrder(tomoXService *tomox.TomoX, statedb *state.StateDB, tomoxStatedb *tomox_state.TomoXStateDB, txMatchBatch tomox.TxMatchBatch) error {
 	log.Debug("verify matching transaction found a TxMatches Batch", "numTxMatches", len(txMatchBatch.Data))
 
 	var trades []map[string]string

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1367,6 +1367,35 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		if err != nil {
 			return i, events, coalescedLogs, err
 		}
+		var tomoxState *tomox_state.TomoXStateDB
+		if tomoXService != nil {
+			txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())
+			if err != nil {
+				return i, events, coalescedLogs, err
+			}
+			tomoxState, err = tomoXService.GetTomoxState(parent)
+			if err != nil {
+				return i, events, coalescedLogs, err
+			}
+			for _, txMatchBatch := range txMatchBatchData {
+				log.Debug("Verify matching transaction", "txHash", txMatchBatch.TxHash.Hex())
+				err := bc.Validator().ValidateMatchingOrder(tomoXService, statedb, tomoxState, txMatchBatch)
+				if err != nil {
+					return i, events, coalescedLogs, err
+				}
+			}
+			if len(txMatchBatchData) > 0 {
+				gotRoot := tomoxState.IntermediateRoot()
+				expectRoot, _ := tomoXService.GetTomoxStateRoot(block)
+				if gotRoot != expectRoot {
+					err = fmt.Errorf("invalid tomox merke trie got : %s , expect : %s ", gotRoot.Hex(), expectRoot.Hex())
+					return i, events, coalescedLogs, err
+				}
+			}
+			parentTomoXRoot, _ := tomoXService.GetTomoxStateRoot(parent)
+			nextTomoxRoot, _ := tomoXService.GetTomoxStateRoot(block)
+			log.Debug("TomoX State Root", "number", block.NumberU64(), "parent", parentTomoXRoot.Hex(), "nextTomoxRoot", nextTomoxRoot.Hex())
+		}
 		feeCapacity := state.GetTRC21FeeCapacityFromStateWithCache(parent.Root(), statedb)
 		// Process block using the parent state as reference point.
 		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, feeCapacity)
@@ -1379,41 +1408,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		if err != nil {
 			bc.reportBlock(block, receipts, err)
 			return i, events, coalescedLogs, err
-		}
-		hashNoValidator := block.HashNoValidator()
-		// clear the previous dry-run cache
-		var tomoxState *tomox_state.TomoXStateDB
-		if tomoXService != nil {
-			txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())
-			if err != nil {
-				bc.reportBlock(block, receipts, err)
-				return i, events, coalescedLogs, err
-			}
-			tomoxState, err = tomoXService.GetTomoxState(parent)
-			if err != nil {
-				bc.reportBlock(block, receipts, err)
-				return i, events, coalescedLogs, err
-			}
-			for _, txMatchBatch := range txMatchBatchData {
-				log.Debug("Verify matching transaction", "txHash", txMatchBatch.TxHash.Hex())
-				err := bc.Validator().ValidateMatchingOrder(tomoXService, statedb, tomoxState, txMatchBatch, hashNoValidator)
-				if err != nil {
-					bc.reportBlock(block, receipts, err)
-					return i, events, coalescedLogs, err
-				}
-			}
-			if len(txMatchBatchData) > 0 {
-				gotRoot := tomoxState.IntermediateRoot()
-				expectRoot, _ := tomoXService.GetTomoxStateRoot(block)
-				if gotRoot != expectRoot {
-					err = fmt.Errorf("invalid tomox merke trie got : %s , expect : %s ", gotRoot.Hex(), expectRoot.Hex())
-					bc.reportBlock(block, receipts, err)
-					return i, events, coalescedLogs, err
-				}
-			}
-			parentTomoXRoot, _ := tomoXService.GetTomoxStateRoot(parent)
-			nextTomoxRoot, _ := tomoXService.GetTomoxStateRoot(block)
-			log.Debug("TomoX State Root", "number", block.NumberU64(), "parent", parentTomoXRoot.Hex(), "nextTomoxRoot", nextTomoxRoot.Hex())
 		}
 		proctime := time.Since(bstart)
 		// Write the block to the chain and get the status.
@@ -1593,6 +1587,40 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 	if err != nil {
 		return nil, err
 	}
+	var tomoXService *tomox.TomoX
+	engine, ok := bc.Engine().(*posv.Posv)
+	if ok {
+		tomoXService = engine.GetTomoXService()
+	}
+	var tomoxState *tomox_state.TomoXStateDB
+	if tomoXService != nil {
+		tomoxState, err = tomoXService.GetTomoxState(parent)
+		if err != nil {
+			return nil, err
+		}
+		txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())
+		if err != nil {
+			return nil, err
+		}
+		for _, txMatchBatch := range txMatchBatchData {
+			log.Debug("Verify matching transaction", "txHash", txMatchBatch.TxHash.Hex())
+			err := bc.Validator().ValidateMatchingOrder(tomoXService, statedb, tomoxState, txMatchBatch)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if len(txMatchBatchData) > 0 {
+			gotRoot := tomoxState.IntermediateRoot()
+			expectRoot, _ := tomoXService.GetTomoxStateRoot(block)
+			if gotRoot != expectRoot {
+				err = fmt.Errorf("invalid tomox merke trie got : %s , expect : %s ", gotRoot.Hex(), expectRoot.Hex())
+				return nil, err
+			}
+		}
+		parentTomoXRoot, _ := tomoXService.GetTomoxStateRoot(parent)
+		nextTomoxRoot, _ := tomoXService.GetTomoxStateRoot(block)
+		log.Debug("TomoX State Root", "number", block.NumberU64(), "parent", parentTomoXRoot.Hex(), "nextTomoxRoot", nextTomoxRoot.Hex())
+	}
 	feeCapacity := state.GetTRC21FeeCapacityFromStateWithCache(parent.Root(), statedb)
 	// Process block using the parent state as reference point.
 	receipts, logs, usedGas, err := bc.processor.ProcessBlockNoValidator(calculatedBlock, statedb, bc.vmConfig, feeCapacity)
@@ -1612,44 +1640,6 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 	proctime := time.Since(bstart)
 	log.Debug("Calculate new block", "number", block.Number(), "hash", block.Hash(), "uncles", len(block.Uncles()),
 		"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)), "process", process)
-	var tomoXService *tomox.TomoX
-	engine, ok := bc.Engine().(*posv.Posv)
-	if ok {
-		tomoXService = engine.GetTomoXService()
-	}
-	var tomoxState *tomox_state.TomoXStateDB
-	if tomoXService != nil {
-		tomoxState, err = tomoXService.GetTomoxState(parent)
-		if err != nil {
-			bc.reportBlock(block, receipts, err)
-			return nil, err
-		}
-		txMatchBatchData, err := ExtractMatchingTransactions(block.Transactions())
-		if err != nil {
-			bc.reportBlock(block, receipts, err)
-			return nil, err
-		}
-		for _, txMatchBatch := range txMatchBatchData {
-			log.Debug("Verify matching transaction", "txHash", txMatchBatch.TxHash.Hex())
-			err := bc.Validator().ValidateMatchingOrder(tomoXService, statedb, tomoxState, txMatchBatch, block.HashNoValidator())
-			if err != nil {
-				bc.reportBlock(block, receipts, err)
-				return nil, err
-			}
-		}
-		if len(txMatchBatchData) > 0 {
-			gotRoot := tomoxState.IntermediateRoot()
-			expectRoot, _ := tomoXService.GetTomoxStateRoot(block)
-			if gotRoot != expectRoot {
-				err = fmt.Errorf("invalid tomox merke trie got : %s , expect : %s ", gotRoot.Hex(), expectRoot.Hex())
-				bc.reportBlock(block, receipts, err)
-				return nil, err
-			}
-		}
-		parentTomoXRoot, _ := tomoXService.GetTomoxStateRoot(parent)
-		nextTomoxRoot, _ := tomoXService.GetTomoxStateRoot(block)
-		log.Debug("TomoX State Root", "number", block.NumberU64(), "parent", parentTomoXRoot.Hex(), "nextTomoxRoot", nextTomoxRoot.Hex())
-	}
 	return &ResultProcessBlock{receipts: receipts, logs: logs, state: statedb, tomoxState: tomoxState, proctime: proctime, usedGas: usedGas}, nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2255,11 +2255,14 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 	for _, txMatchBatch := range txMatchBatchData {
 		for _, txMatch := range txMatchBatch.Data {
 			resultTrades, ok := bc.resultTrades.Get(txMatchBatch.TxHash)
-			if !ok {
-				log.Error("no trades found to update mongodb")
-				return
+			var trades []map[string]string
+			if !ok || resultTrades == nil {
+				log.Debug("no trades found to update mongodb. Update order only", "txhash", txMatchBatch.TxHash)
+				trades = []map[string]string{}
+			} else {
+				trades = resultTrades.([]map[string]string)
 			}
-			trades := resultTrades.([]map[string]string)
+
 			// remove from cache
 			bc.resultTrades.Remove(txMatchBatch.TxHash)
 			txMatchTime := time.Unix(0, txMatchBatch.Timestamp)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -311,125 +311,126 @@ func ApplyEmptyTransaction(config *params.ChainConfig, statedb *state.StateDB, h
 }
 func ApplyTomoXMatchedTransaction(config *params.ChainConfig, bc *BlockChain, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64) (*types.Receipt, uint64, error, bool) {
 	// Update the state with pending changes
-	txMatchBatches, err := tomox.DecodeTxMatchesBatch(tx.Data())
-	if err != nil {
-		return nil, 0, err, false
+	resultTrades, ok := bc.resultTrades.Get(tx.Hash())
+	if !ok {
+		return nil, 0, fmt.Errorf("no trade found"), false
 	}
-	matchingFee := big.NewInt(0)
-	for _, txMatch := range txMatchBatches.Data {
-		orderItem, err := txMatch.DecodeOrder()
-		if err != nil {
-			return nil, 0, err, false
+	trades := resultTrades.([]map[string]string)
+	engine, ok := bc.Engine().(*posv.Posv)
+	var tomoXService *tomox.TomoX
+	if ok {
+		tomoXService = engine.GetTomoXService()
+	}
+	if tomoXService == nil {
+		return nil, 0, tomox.ErrTomoXServiceNotFound, false
+	}
+	defer func() {
+		// SDK nodes need to keep resultTrade to update mongodb, will remove cache after that
+		if !tomoXService.IsSDKNode() {
+			bc.resultTrades.Remove(tx.Hash())
 		}
-		takerAddr := orderItem.UserAddress
-		takerExAddr := orderItem.ExchangeAddress
-		takerExOwner := tomox_state.GetRelayerOwner(orderItem.ExchangeAddress, statedb)
-		baseToken := orderItem.BaseToken
-		quoteToken := orderItem.QuoteToken
-		takerExfee := tomox_state.GetExRelayerFee(orderItem.ExchangeAddress, statedb)
-		baseFee := common.TomoXBaseFee
+	}()
+	matchingFee := big.NewInt(0)
+	baseFee := common.TomoXBaseFee
+	for i := 0; i < len(trades); i++ {
+		takerAddr := common.HexToAddress(trades[i][tomox.TradeTaker])
+		takerExAddr := common.HexToAddress(trades[i][tomox.TradeTakerExchange])
+		takerExOwner := tomox_state.GetRelayerOwner(takerExAddr, statedb)
+		baseToken := common.HexToAddress(trades[i][tomox.TradeBaseToken])
+		quoteToken := common.HexToAddress(trades[i][tomox.TradeQuoteToken])
+		takerExfee := tomox_state.GetExRelayerFee(takerExAddr, statedb)
 
-		for i := 0; i < len(txMatch.Trades); i++ {
-			price := tomox.ToBigInt(txMatch.Trades[i][tomox.TradePrice])
-			quantityString := txMatch.Trades[i][tomox.TradeQuantity]
-			quantity := tomox.ToBigInt(quantityString)
-			if price.Cmp(big.NewInt(0)) <= 0 || quantity.Cmp(big.NewInt(0)) <= 0 {
-				return nil, 0, fmt.Errorf("trade misses important information. tradedPrice %v, tradedQuantity %v", price, quantity), false
+		price := tomox.ToBigInt(trades[i][tomox.TradePrice])
+		quantityString := trades[i][tomox.TradeQuantity]
+		quantity := tomox.ToBigInt(quantityString)
+		if price.Cmp(big.NewInt(0)) <= 0 || quantity.Cmp(big.NewInt(0)) <= 0 {
+			return nil, 0, fmt.Errorf("trade misses important information. tradedPrice %v, tradedQuantity %v", price, quantity), false
+		}
+		makerExAddr := common.HexToAddress(trades[i][tomox.TradeMakerExchange])
+		makerExfee := tomox_state.GetExRelayerFee(makerExAddr, statedb)
+		makerExOwner := tomox_state.GetRelayerOwner(makerExAddr, statedb)
+		makerAddr := common.HexToAddress(trades[i][tomox.TradeMaker])
+		log.Debug("ApplyTomoXMatchedTransaction : trades quantityString", "i", i, "trade", trades[i], "price", price)
+		if makerExAddr != (common.Address{}) && makerAddr != (common.Address{}) {
+			// take relayer fee
+			err := tomox_state.SubRelayerFee(takerExAddr, common.RelayerFee, statedb)
+			if err != nil {
+				return nil, 0, err, false
 			}
-			makerExAddr := common.HexToAddress(txMatch.Trades[i][tomox.TradeMakerExchange])
-			makerExfee := tomox_state.GetExRelayerFee(makerExAddr, statedb)
-			makerExOwner := tomox_state.GetRelayerOwner(makerExAddr, statedb)
-			makerAddr := common.HexToAddress(txMatch.Trades[i][tomox.TradeMaker])
-			log.Debug("ApplyTomoXMatchedTransaction : trades quantityString", "i", i, "trade", txMatch.Trades[i], "price", price)
-			if makerExAddr != (common.Address{}) && makerAddr != (common.Address{}) {
-				// take relayer fee
-				err := tomox_state.SubRelayerFee(takerExAddr, common.RelayerFee, statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
-				err = tomox_state.SubRelayerFee(makerExAddr, common.RelayerFee, statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
+			err = tomox_state.SubRelayerFee(makerExAddr, common.RelayerFee, statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
 
-				// masternodes charges fee of both 2 relayers. If maker and taker are on same relayer, that relayer is charged fee twice
-				matchingFee = matchingFee.Add(matchingFee, common.RelayerFee)
-				matchingFee = matchingFee.Add(matchingFee, common.RelayerFee)
+			// masternodes charges fee of both 2 relayers. If maker and taker are on same relayer, that relayer is charged fee twice
+			matchingFee = matchingFee.Add(matchingFee, common.RelayerFee)
+			matchingFee = matchingFee.Add(matchingFee, common.RelayerFee)
 
-				//log.Debug("ApplyTomoXMatchedTransaction quantity check", "i", i, "trade", txMatch.Trades[i], "price", price, "quantity", quantity)
+			//log.Debug("ApplyTomoXMatchedTransaction quantity check", "i", i, "trade", txMatch.Trades[i], "price", price, "quantity", quantity)
 
-				isTakerBuy := orderItem.Side == tomox.Bid
-				engine, ok := bc.Engine().(*posv.Posv)
-				var tomoXService *tomox.TomoX
-				if ok {
-					tomoXService = engine.GetTomoXService()
-				}
-				if tomoXService == nil {
-					return nil, 0, tomox.ErrTomoXServiceNotFound, false
-				}
-				settleBalanceResult, err := tomoXService.SettleBalance(
-					bc.IPCEndpoint,
-					makerAddr,
-					takerAddr,
-					baseToken,
-					quoteToken,
-					isTakerBuy,
-					makerExfee,
-					takerExfee,
-					baseFee,
-					quantity,
-					price)
-				if err != nil {
-					return nil, 0, err, false
-				}
-				// TAKER
-				//log.Debug("ApplyTomoXMatchedTransaction settle balance for taker",
-				//	"taker", takerAddr,
-				//	"inToken", settleBalanceResult[takerAddr][tomox.InToken].(common.Address), "inQuantity", settleBalanceResult[takerAddr][tomox.InQuantity].(*big.Int),
-				//	"inTotal", settleBalanceResult[takerAddr][tomox.InTotal].(*big.Int),
-				//	"outToken", settleBalanceResult[takerAddr][tomox.OutToken].(common.Address), "outQuantity", settleBalanceResult[takerAddr][tomox.OutQuantity].(*big.Int),
-				//	"outTotal", settleBalanceResult[takerAddr][tomox.OutTotal].(*big.Int))
-				err = tomox_state.AddTokenBalance(takerAddr, settleBalanceResult[takerAddr][tomox.InTotal].(*big.Int), settleBalanceResult[takerAddr][tomox.InToken].(common.Address), statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
-				err = tomox_state.SubTokenBalance(takerAddr, settleBalanceResult[takerAddr][tomox.OutTotal].(*big.Int), settleBalanceResult[takerAddr][tomox.OutToken].(common.Address), statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
+			isTakerBuy := trades[i][tomox.TradeTakerSide] == tomox.Bid
+			settleBalanceResult, err := tomoXService.SettleBalance(
+				bc.IPCEndpoint,
+				makerAddr,
+				takerAddr,
+				baseToken,
+				quoteToken,
+				isTakerBuy,
+				makerExfee,
+				takerExfee,
+				baseFee,
+				quantity,
+				price)
+			if err != nil {
+				return nil, 0, err, false
+			}
+			// TAKER
+			//log.Debug("ApplyTomoXMatchedTransaction settle balance for taker",
+			//	"taker", takerAddr,
+			//	"inToken", settleBalanceResult[takerAddr][tomox.InToken].(common.Address), "inQuantity", settleBalanceResult[takerAddr][tomox.InQuantity].(*big.Int),
+			//	"inTotal", settleBalanceResult[takerAddr][tomox.InTotal].(*big.Int),
+			//	"outToken", settleBalanceResult[takerAddr][tomox.OutToken].(common.Address), "outQuantity", settleBalanceResult[takerAddr][tomox.OutQuantity].(*big.Int),
+			//	"outTotal", settleBalanceResult[takerAddr][tomox.OutTotal].(*big.Int))
+			err = tomox_state.AddTokenBalance(takerAddr, settleBalanceResult[takerAddr][tomox.InTotal].(*big.Int), settleBalanceResult[takerAddr][tomox.InToken].(common.Address), statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
+			err = tomox_state.SubTokenBalance(takerAddr, settleBalanceResult[takerAddr][tomox.OutTotal].(*big.Int), settleBalanceResult[takerAddr][tomox.OutToken].(common.Address), statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
 
-				// MAKER
-				//log.Debug("ApplyTomoXMatchedTransaction settle balance for maker",
-				//	"maker", makerAddr,
-				//	"inToken", settleBalanceResult[makerAddr][tomox.InToken].(common.Address), "inQuantity", settleBalanceResult[makerAddr][tomox.InQuantity].(*big.Int),
-				//	"inTotal", settleBalanceResult[makerAddr][tomox.InTotal].(*big.Int),
-				//	"outToken", settleBalanceResult[makerAddr][tomox.OutToken].(common.Address), "outQuantity", settleBalanceResult[makerAddr][tomox.OutQuantity].(*big.Int),
-				//	"outTotal", settleBalanceResult[makerAddr][tomox.OutTotal].(*big.Int))
-				err = tomox_state.AddTokenBalance(makerAddr, settleBalanceResult[makerAddr][tomox.InTotal].(*big.Int), settleBalanceResult[makerAddr][tomox.InToken].(common.Address), statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
-				err = tomox_state.SubTokenBalance(makerAddr, settleBalanceResult[makerAddr][tomox.OutTotal].(*big.Int), settleBalanceResult[makerAddr][tomox.OutToken].(common.Address), statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
+			// MAKER
+			//log.Debug("ApplyTomoXMatchedTransaction settle balance for maker",
+			//	"maker", makerAddr,
+			//	"inToken", settleBalanceResult[makerAddr][tomox.InToken].(common.Address), "inQuantity", settleBalanceResult[makerAddr][tomox.InQuantity].(*big.Int),
+			//	"inTotal", settleBalanceResult[makerAddr][tomox.InTotal].(*big.Int),
+			//	"outToken", settleBalanceResult[makerAddr][tomox.OutToken].(common.Address), "outQuantity", settleBalanceResult[makerAddr][tomox.OutQuantity].(*big.Int),
+			//	"outTotal", settleBalanceResult[makerAddr][tomox.OutTotal].(*big.Int))
+			err = tomox_state.AddTokenBalance(makerAddr, settleBalanceResult[makerAddr][tomox.InTotal].(*big.Int), settleBalanceResult[makerAddr][tomox.InToken].(common.Address), statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
+			err = tomox_state.SubTokenBalance(makerAddr, settleBalanceResult[makerAddr][tomox.OutTotal].(*big.Int), settleBalanceResult[makerAddr][tomox.OutToken].(common.Address), statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
 
-				// add balance for relayers
-				//log.Debug("ApplyTomoXMatchedTransaction settle fee for relayers",
-				//	"takerRelayerOwner", takerExOwner,
-				//	"takerFeeToken", quoteToken, "takerFee", settleBalanceResult[takerAddr][tomox.Fee].(*big.Int),
-				//	"makerRelayerOwner", makerExOwner,
-				//	"makerFeeToken", quoteToken, "makerFee", settleBalanceResult[makerAddr][tomox.Fee].(*big.Int))
-				// takerFee
-				err = tomox_state.AddTokenBalance(takerExOwner, settleBalanceResult[takerAddr][tomox.Fee].(*big.Int), quoteToken, statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
-				// makerFee
-				err = tomox_state.AddTokenBalance(makerExOwner, settleBalanceResult[makerAddr][tomox.Fee].(*big.Int), quoteToken, statedb)
-				if err != nil {
-					return nil, 0, err, false
-				}
+			// add balance for relayers
+			//log.Debug("ApplyTomoXMatchedTransaction settle fee for relayers",
+			//	"takerRelayerOwner", takerExOwner,
+			//	"takerFeeToken", quoteToken, "takerFee", settleBalanceResult[takerAddr][tomox.Fee].(*big.Int),
+			//	"makerRelayerOwner", makerExOwner,
+			//	"makerFeeToken", quoteToken, "makerFee", settleBalanceResult[makerAddr][tomox.Fee].(*big.Int))
+			// takerFee
+			err = tomox_state.AddTokenBalance(takerExOwner, settleBalanceResult[takerAddr][tomox.Fee].(*big.Int), quoteToken, statedb)
+			if err != nil {
+				return nil, 0, err, false
+			}
+			// makerFee
+			err = tomox_state.AddTokenBalance(makerExOwner, settleBalanceResult[makerAddr][tomox.Fee].(*big.Int), quoteToken, statedb)
+			if err != nil {
+				return nil, 0, err, false
 			}
 		}
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -38,7 +38,7 @@ type Validator interface {
 	// gas used.
 	ValidateState(block, parent *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error
 
-	ValidateMatchingOrder(tomoXService *tomox.TomoX, statedb *state.StateDB, tomoxStatedb *tomox_state.TomoXStateDB, txMatchBatch tomox.TxMatchBatch, blockHash common.Hash) error
+	ValidateMatchingOrder(tomoXService *tomox.TomoX, statedb *state.StateDB, tomoxStatedb *tomox_state.TomoXStateDB, txMatchBatch tomox.TxMatchBatch) error
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -15,14 +15,15 @@ type DecodeBytes func([]byte, interface{}) error
 type FormatBytes func([]byte) string
 
 const (
-	TrueByte  = byte(1)
-	FalseByte = byte(0)
-	decimals  = 18
-	Ask    = "SELL"
-	Bid    = "BUY"
-	Market = "MO"
-	Limit  = "LO"
-	Cancel = "CANCELLED"
+	TrueByte        = byte(1)
+	FalseByte       = byte(0)
+	decimals        = 18
+	Ask             = "SELL"
+	Bid             = "BUY"
+	Market          = "MO"
+	Limit           = "LO"
+	Cancel          = "CANCELLED"
+	CommitNewWorkTx = "COMMIT_NEW_WORK_TX"
 )
 
 var (
@@ -268,8 +269,4 @@ func (tx TxDataMatch) DecodeOrder() (*tomox_state.OrderItem, error) {
 		return order, err
 	}
 	return order, nil
-}
-
-func (tx TxDataMatch) GetTrades() []map[string]string {
-	return tx.Trades
 }

--- a/tomox/common_test.go
+++ b/tomox/common_test.go
@@ -13,15 +13,12 @@ func TestTxMatchesBatch(t *testing.T) {
 	originalTxMatchesBatch := []TxDataMatch{
 		{
 			Order:       []byte("order1"),
-			Trades:      []map[string]string{{"takerOrderHash": "hash11"}, {"takerOrderHash": "hash12"}},
 		},
 		{
 			Order:       []byte("order2"),
-			Trades:      []map[string]string{{"takerOrderHash": "hash21"}, {"takerOrderHash": "hash22"}},
 		},
 		{
 			Order:       []byte("order3"),
-			Trades:      []map[string]string{{"takerOrderHash": "hash31"}, {"takerOrderHash": "hash32"}},
 		},
 	}
 

--- a/tomox/order_processor.go
+++ b/tomox/order_processor.go
@@ -189,21 +189,24 @@ func processOrderList(statedb *state.StateDB, tomoXstatedb *tomox_state.TomoXSta
 		log.Debug("Update quantity for orderId", "orderId", orderId.Hex())
 		log.Debug("TRADE", "orderBook", orderBook, "Price 1", price, "Price 2", order.Price, "Amount", tradedQuantity, "orderId", orderId, "side", side)
 
-		transactionRecord := make(map[string]string)
-		transactionRecord[TradeTakerOrderHash] = hex.EncodeToString(order.Hash.Bytes())
-		transactionRecord[TradeMakerOrderHash] = hex.EncodeToString(oldestOrder.Hash.Bytes())
-		transactionRecord[TradeTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)
-		transactionRecord[TradeQuantity] = tradedQuantity.String()
-		transactionRecord[TradeMakerExchange] = oldestOrder.ExchangeAddress.String()
-		transactionRecord[TradeMaker] = oldestOrder.UserAddress.String()
-		transactionRecord[TradeBaseToken] = oldestOrder.BaseToken.String()
-		transactionRecord[TradeQuoteToken] = oldestOrder.QuoteToken.String()
+		tradeRecord := make(map[string]string)
+		tradeRecord[TradeTakerOrderHash] = hex.EncodeToString(order.Hash.Bytes())
+		tradeRecord[TradeMakerOrderHash] = hex.EncodeToString(oldestOrder.Hash.Bytes())
+		tradeRecord[TradeTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)
+		tradeRecord[TradeQuantity] = tradedQuantity.String()
+		tradeRecord[TradeMakerExchange] = oldestOrder.ExchangeAddress.String()
+		tradeRecord[TradeTakerExchange] = order.ExchangeAddress.String()
+		tradeRecord[TradeMaker] = oldestOrder.UserAddress.String()
+		tradeRecord[TradeTaker] = order.UserAddress.String()
+		tradeRecord[TradeBaseToken] = oldestOrder.BaseToken.String()
+		tradeRecord[TradeQuoteToken] = oldestOrder.QuoteToken.String()
 		// maker price is actual price
 		// taker price is offer price
 		// tradedPrice is always actual price
-		transactionRecord[TradePrice] = oldestOrder.Price.String()
+		tradeRecord[TradePrice] = oldestOrder.Price.String()
+		tradeRecord[TradeTakerSide] = oldestOrder.Side
 
-		trades = append(trades, transactionRecord)
+		trades = append(trades, tradeRecord)
 		orderId, amount, err = tomoXstatedb.GetBestOrderIdAndAmount(orderBook, price, side)
 		if err != nil {
 			return nil, nil, nil, err

--- a/tomox/trade.go
+++ b/tomox/trade.go
@@ -19,10 +19,13 @@ const (
 	TradeTimestamp      = "timestamp"
 	TradeQuantity       = "quantity"
 	TradeMakerExchange  = "makerExAddr"
-	TradeMaker          = "uAddr"
+	TradeTakerExchange  = "takerExAddr"
+	TradeMaker          = "makerUAddr"
+	TradeTaker          = "takerUAddr"
 	TradeBaseToken      = "bToken"
 	TradeQuoteToken     = "qToken"
 	TradePrice          = "tradedPrice"
+	TradeTakerSide      = "takerSide"
 )
 
 type Trade struct {


### PR DESCRIPTION
fix #779 

Changes in this PR:
- Removing `trades` from txdata
- All nodes run matching engine with input order (in txdata), generate trades then use them to settle balances and update mongodb for SDK
- Currently, we applied txns and settled balance before validating orders / running matching engine :man_facepalming:
  I corrected this at https://github.com/tomochain/tomochain/pull/780/commits/4645b6cc3e8578872026d8bc925218a30555f14f