### PR TITLE
Reorg txMatches (mongodb)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2262,13 +2262,13 @@ func (bc *BlockChain) reorgTxMatches (deletedTxs types.Transactions, newChain ty
 	}
 	for _, deletedTx := range deletedTxs {
 		if deletedTx.IsMatchingTransaction() {
-			log.Debug("Removing reorg txMatch", "txhash", deletedTx.Hash())
-			tomoXService.RemoveReorgTxMatch(deletedTx.Hash())
+			log.Debug("Rollback reorg txMatch", "txhash", deletedTx.Hash())
+			tomoXService.RollbackReorgTxMatch(deletedTx.Hash())
 		}
 	}
 
 	// apply new chain
-	for i := len(newChain) - 1; i >=0; i-- {
+	for i := len(newChain) - 1; i >= 0; i-- {
 		bc.logExchangeData(newChain[i])
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1920,7 +1920,9 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			}
 		}()
 	}
-
+	if bc.chainConfig.IsTIPTomoX(commonBlock.Number()) {
+		bc.reorgTxMatches(deletedTxs, newChain)
+	}
 	return nil
 }
 
@@ -2246,5 +2248,27 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 				return
 			}
 		}
+	}
+}
+
+func (bc *BlockChain) reorgTxMatches (deletedTxs types.Transactions, newChain types.Blocks) {
+	var tomoXService *tomox.TomoX
+	engine, ok := bc.Engine().(*posv.Posv)
+	if ok {
+		tomoXService = engine.GetTomoXService()
+	}
+	if tomoXService == nil || !tomoXService.IsSDKNode() {
+		return
+	}
+	for _, deletedTx := range deletedTxs {
+		if deletedTx.IsMatchingTransaction() {
+			log.Debug("Removing reorg txMatch", "txhash", deletedTx.Hash())
+			tomoXService.RemoveReorgTxMatch(deletedTx.Hash())
+		}
+	}
+
+	// apply new chain
+	for i := len(newChain) - 1; i >=0; i-- {
+		bc.logExchangeData(newChain[i])
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2251,7 +2251,7 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 	}
 }
 
-func (bc *BlockChain) reorgTxMatches (deletedTxs types.Transactions, newChain types.Blocks) {
+func (bc *BlockChain) reorgTxMatches(deletedTxs types.Transactions, newChain types.Blocks) {
 	var tomoXService *tomox.TomoX
 	engine, ok := bc.Engine().(*posv.Posv)
 	if ok {

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -16,8 +16,6 @@
 
 package ethdb
 
-import "github.com/ethereum/go-ethereum/common"
-
 // Code using batches should try to add this much data to the batch.
 // The value was determined empirically.
 const IdealBatchSize = 100 * 1024
@@ -39,7 +37,7 @@ type Database interface {
 
 // TomoxDatabase interface
 type TomoxDatabase interface {
-	GetObject(key []byte, val interface{}, dryrun bool, blockHash common.Hash) (interface{}, error)
+	GetObject(key []byte, val interface{}) (interface{}, error)
 }
 
 // Batch is a write-only database that commits changes to its host database

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -57,6 +57,12 @@ var (
 	ErrInvalidDryRunResult  = errors.New("failed to apply txMatches, invalid dryRun result")
 )
 
+type OrderHistoryItem struct {
+	TxHash common.Hash
+	FilledAmount *big.Int
+	Status string
+}
+
 // use alloc to prevent reference manipulation
 func EmptyKey() []byte {
 	key := make([]byte, common.HashLength)

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/ethereum/go-ethereum/tomox/tomox_state"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -18,11 +19,11 @@ const (
 	TrueByte  = byte(1)
 	FalseByte = byte(0)
 	decimals  = 18
-	Ask    = "SELL"
-	Bid    = "BUY"
-	Market = "MO"
-	Limit  = "LO"
-	Cancel = "CANCELLED"
+	Ask       = "SELL"
+	Bid       = "BUY"
+	Market    = "MO"
+	Limit     = "LO"
+	Cancel    = "CANCELLED"
 )
 
 var (
@@ -58,9 +59,9 @@ var (
 )
 
 type OrderHistoryItem struct {
-	TxHash common.Hash
+	TxHash       common.Hash
 	FilledAmount *big.Int
-	Status string
+	Status       string
 }
 
 // use alloc to prevent reference manipulation
@@ -268,6 +269,9 @@ func DecodeTxMatchesBatch(data []byte) (TxMatchBatch, error) {
 	return txMatchResult, nil
 }
 
+func GetOrderHistoryKey(pairName string, orderId uint64) common.Hash {
+	return common.StringToHash(pairName + strconv.FormatUint(orderId, 10))
+}
 func (tx TxDataMatch) DecodeOrder() (*tomox_state.OrderItem, error) {
 	order := &tomox_state.OrderItem{}
 	if err := DecodeBytesItem(tx.Order, order); err != nil {

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -3,18 +3,21 @@ package tomox
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/tomox/tomox_state"
 )
 
 type OrderDao interface {
 	IsEmptyKey(key []byte) bool
-	HasObject(key []byte, dryrun bool, blockHash common.Hash) (bool, error)
-	GetObject(key []byte, val interface{}, dryrun bool, blockHash common.Hash) (interface{}, error)
-	PutObject(key []byte, val interface{}, dryrun bool, blockHash common.Hash) error
-	DeleteObject(key []byte, dryrun bool, blockHash common.Hash) error // won't return error if key not found
+	HasObject(key []byte) (bool, error)
+	GetObject(key []byte, val interface{}) (interface{}, error)
+	PutObject(key []byte, val interface{}) error
+	DeleteObject(key []byte) error // won't return error if key not found
 	Put(key []byte, value []byte) error
 	Get(key []byte) ([]byte, error)
 	Has(key []byte) (bool, error)
 	Delete(key []byte) error
+	GetOrderByTxHash(txhash common.Hash) []*tomox_state.OrderItem
+	DeleteTradeByTxHash(txhash common.Hash)
 	Close()
 	NewBatch() ethdb.Batch
 }

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -443,7 +443,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 		log.Debug("Tomox reorg: rollback order", "txhash", txhash.Hex(), "order", ToJSON(order), "orderHistoryItem", c)
 		if !ok {
 			log.Debug("Tomox reorg: remove order due to no orderCache", "order", ToJSON(order))
-			if err := db.DeleteObject([]byte(order.Key)); err != nil {
+			if err := db.DeleteObject(order.Hash.Bytes()); err != nil {
 				log.Error("SDKNode: failed to remove reorg order", "err", err.Error(), "order", ToJSON(order))
 			}
 			continue
@@ -452,7 +452,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 		orderHistoryItem, _ := orderCacheAtTxHash[GetOrderHistoryKey(order.PairName, order.OrderID)]
 		if (orderHistoryItem == OrderHistoryItem{}) {
 			log.Debug("Tomox reorg: remove order due to empty orderHistory", "order", ToJSON(order))
-			if err := db.DeleteObject([]byte(order.Key)); err != nil {
+			if err := db.DeleteObject(order.Hash.Bytes()); err != nil {
 				log.Error("SDKNode: failed to remove reorg order", "err", err.Error(), "order", ToJSON(order))
 			}
 			continue

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -69,6 +69,7 @@ type TomoX struct {
 	sdkNode           bool
 	settings          syncmap.Map // holds configuration settings that can be dynamically changed
 	tokenDecimalCache *lru.Cache
+	orderCache        *lru.Cache
 }
 
 func (tomox *TomoX) Protocols() []p2p.Protocol {
@@ -101,10 +102,12 @@ func NewMongoDBEngine(cfg *Config) *MongoDatabase {
 
 func New(cfg *Config) *TomoX {
 	tokenDecimalCache, _ := lru.New(defaultCacheLimit)
+	orderCache, _ := lru.New(defaultCacheLimit)
 	tomoX := &TomoX{
 		orderNonce:        make(map[common.Address]*big.Int),
 		Triegc:            prque.New(),
 		tokenDecimalCache: tokenDecimalCache,
+		orderCache:        orderCache,
 	}
 
 	// default DBEngine: levelDB
@@ -269,6 +272,16 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		log.Error("SDK node decode order failed", "txDataMatch", txDataMatch)
 		return fmt.Errorf("SDK node decode order failed")
 	}
+	lastState := OrderHistoryItem{}
+	val, err := db.GetObject(order.Hash.Bytes(), &tomox_state.OrderItem{})
+	if err == nil && val != nil {
+		originOrder := val.(*tomox_state.OrderItem)
+		lastState = OrderHistoryItem{
+			TxHash:       originOrder.TxHash,
+			FilledAmount: CloneBigInt(originOrder.FilledAmount),
+			Status:       originOrder.Status,
+		}
+	}
 
 	if order.Status != OrderStatusCancelled {
 		order.Status = OrderStatusOpen
@@ -278,8 +291,11 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		order.CreatedAt = txMatchTime
 	}
 	order.UpdatedAt = txMatchTime
+
+	tomox.UpdateOrderCache(order.PairName, order.OrderID, txHash, lastState)
+
 	log.Debug("PutObject processed order", "order", order)
-	if err := db.PutObject(order.Hash.Bytes(), order, false, common.Hash{}); err != nil {
+	if err := db.PutObject(order.Hash.Bytes(), order); err != nil {
 		return fmt.Errorf("SDKNode: failed to put processed order. Error: %s", err.Error())
 	}
 	if order.Status == OrderStatusCancelled {
@@ -330,33 +346,40 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		// 2.b. update status and filledAmount
 		filledAmount := quantity
 		// update order status of relating orders
-		if err := tomox.updateMatchedOrder(trade[TradeMakerOrderHash], filledAmount, txMatchTime); err != nil {
+		if err := tomox.updateMatchedOrder(trade[TradeMakerOrderHash], filledAmount, txMatchTime, txHash); err != nil {
 			return err
 		}
-		if err := tomox.updateMatchedOrder(trade[TradeTakerOrderHash], filledAmount, txMatchTime); err != nil {
+		if err := tomox.updateMatchedOrder(trade[TradeTakerOrderHash], filledAmount, txMatchTime, txHash); err != nil {
 			return err
 		}
 
 		log.Debug("TRADE history", "order", order, "trade", tradeRecord)
-		if err := db.PutObject(EmptyKey(), tradeRecord, false, common.Hash{}); err != nil {
+		if err := db.PutObject(EmptyKey(), tradeRecord); err != nil {
 			return fmt.Errorf("SDKNode: failed to store tradeRecord %s", err.Error())
 		}
 	}
 	return nil
 }
 
-func (tomox *TomoX) updateMatchedOrder(hashString string, filledAmount *big.Int, txMatchTime time.Time) error {
+func (tomox *TomoX) updateMatchedOrder(hashString string, filledAmount *big.Int, txMatchTime time.Time, txHash common.Hash) error {
 	log.Debug("updateMatchedOrder", "hash", hashString, "filledAmount", filledAmount)
 	db := tomox.GetMongoDB()
 	orderHashBytes, err := hex.DecodeString(hashString)
 	if err != nil {
 		return fmt.Errorf("SDKNode: failed to decode orderKey. Key: %s", hashString)
 	}
-	val, err := db.GetObject(orderHashBytes, &tomox_state.OrderItem{}, false, common.Hash{})
+	val, err := db.GetObject(orderHashBytes, &tomox_state.OrderItem{})
 	if err != nil || val == nil {
 		return fmt.Errorf("SDKNode: failed to get order. Key: %s", hashString)
 	}
 	matchedOrder := val.(*tomox_state.OrderItem)
+
+	lastState := OrderHistoryItem{
+		TxHash:       matchedOrder.TxHash,
+		FilledAmount: CloneBigInt(matchedOrder.FilledAmount),
+		Status:       matchedOrder.Status,
+	}
+
 	updatedFillAmount := new(big.Int)
 	updatedFillAmount.Add(matchedOrder.FilledAmount, filledAmount)
 	matchedOrder.FilledAmount = updatedFillAmount
@@ -366,9 +389,12 @@ func (tomox *TomoX) updateMatchedOrder(hashString string, filledAmount *big.Int,
 		matchedOrder.Status = OrderStatusFilled
 	}
 	matchedOrder.UpdatedAt = txMatchTime
-	if err = db.PutObject(matchedOrder.Hash.Bytes(), matchedOrder, false, common.Hash{}); err != nil {
+	matchedOrder.TxHash = txHash
+
+	if err = db.PutObject(matchedOrder.Hash.Bytes(), matchedOrder); err != nil {
 		return fmt.Errorf("SDKNode: failed to update matchedOrder to sdkNode %s", err.Error())
 	}
+	tomox.UpdateOrderCache(matchedOrder.PairName, matchedOrder.OrderID, txHash, lastState)
 	return nil
 }
 
@@ -392,4 +418,49 @@ func (tomox *TomoX) GetTomoxStateRoot(block *types.Block) (common.Hash, error) {
 		}
 	}
 	return tomox_state.EmptyRoot, nil
+}
+
+func (tomox *TomoX) UpdateOrderCache(pair string, orderId uint64, txhash common.Hash, lastState OrderHistoryItem) {
+	var orderCacheAtTxHash map[common.Hash]OrderHistoryItem
+	c, ok := tomox.orderCache.Get(txhash)
+	if !ok || c == nil {
+		orderCacheAtTxHash = make(map[common.Hash]OrderHistoryItem)
+	} else {
+		orderCacheAtTxHash = c.(map[common.Hash]OrderHistoryItem)
+	}
+	orderKey := common.StringToHash(pair + strconv.FormatUint(orderId, 10))
+	_, ok = orderCacheAtTxHash[orderKey]
+	if !ok {
+		orderCacheAtTxHash[orderKey] = lastState
+	}
+	tomox.orderCache.Add(txhash, orderCacheAtTxHash)
+}
+
+func (tomox *TomoX) RemoveReorgTxMatch(txhash common.Hash) {
+	db := tomox.GetMongoDB()
+	for _, order := range db.GetOrderByTxHash(txhash) {
+		c, ok := tomox.orderCache.Get(txhash)
+		if !ok {
+			if err := db.DeleteObject([]byte(order.Key)); err != nil {
+				log.Error("SDKNode: failed to remove reorg order", "err", err.Error(), "order", ToJSON(order))
+			}
+			continue
+		}
+		orderCacheAtTxHash := c.(map[common.Hash]OrderHistoryItem)
+		orderHistoryItem, _ := orderCacheAtTxHash[common.StringToHash(order.PairName+strconv.FormatUint(order.OrderID, 10))]
+		if (orderHistoryItem == OrderHistoryItem{}) {
+			if err := db.DeleteObject([]byte(order.Key)); err != nil {
+				log.Error("SDKNode: failed to remove reorg order", "err", err.Error(), "order", ToJSON(order))
+			}
+			continue
+		}
+		order.TxHash = orderHistoryItem.TxHash
+		order.Status = orderHistoryItem.Status
+		order.FilledAmount = CloneBigInt(orderHistoryItem.FilledAmount)
+		if err := db.PutObject(order.Hash.Bytes(), order); err != nil {
+			log.Error("SDKNode: failed to update reorg order", "err", err.Error(), "order", ToJSON(order))
+		}
+	}
+	db.DeleteTradeByTxHash(txhash)
+
 }


### PR DESCRIPTION
**Issue:**  when reorg happens, we need to clean up `orders`, `trades` of fork chain
**Approach:**
- At `txhash` which `order` is updated, cache the last order state (status, filledAmount) -> `orderHistoryCache`
- When reorg happens:
  - For each deletedTx , based on `orderHistoryCache`, rollback order to the last state. 
    If the last state of order is empty, it means that the order doesn't exist before `chain split point`. It's safe to remove it
  - Delete all trades at `deletedTx.Hash()`
  - Insert `orders`, `trades` of newChain
