### PR TITLE
[Tomox-SDK-fullnodes] Mongodb bulk update orders,trades

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2244,7 +2244,7 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 		for _, txMatch := range txMatchBatch.Data {
 			txMatchTime := time.Unix(0, txMatchBatch.Timestamp)
 			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState); err != nil {
-				log.Error("failed to SyncDataToSDKNode current state", "err", err)
+				log.Error("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return
 			}
 		}

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/tomox/tomox_state"
+	"github.com/globalsign/mgo"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -167,4 +168,16 @@ func (db *BatchDatabase) DeleteTradeByTxHash(txhash common.Hash) {
 
 func (db *BatchDatabase) GetOrderByTxHash(txhash common.Hash) []*tomox_state.OrderItem {
 	return []*tomox_state.OrderItem{}
+}
+
+func (db *BatchDatabase) GetListOrderByHashes(hashes []string) []*tomox_state.OrderItem {
+	return []*tomox_state.OrderItem{}
+}
+
+func (db *BatchDatabase) InitBulk() *mgo.Session {
+	return nil
+}
+
+func (db *BatchDatabase) CommitBulk(sc *mgo.Session) error {
+	return nil
 }

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/tomox/tomox_state"
+	"github.com/globalsign/mgo"
 )
 
 type OrderDao interface {
@@ -17,7 +18,10 @@ type OrderDao interface {
 	Has(key []byte) (bool, error)
 	Delete(key []byte) error
 	GetOrderByTxHash(txhash common.Hash) []*tomox_state.OrderItem
+	GetListOrderByHashes(hashes []string) []*tomox_state.OrderItem
 	DeleteTradeByTxHash(txhash common.Hash)
+	InitBulk() *mgo.Session
+	CommitBulk(sc *mgo.Session) error
 	Close()
 	NewBatch() ethdb.Batch
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -238,9 +238,7 @@ func (db *MongoDatabase) InitBulk() *mgo.Session {
 }
 
 func (db *MongoDatabase) CommitBulk(sc *mgo.Session) error {
-	defer func() {
-		sc.Close()
-	}()
+	defer sc.Close()
 	if _, err := db.orderBulk.Run(); err != nil {
 		return err
 	}
@@ -414,6 +412,7 @@ func (db *MongoDatabase) GetListOrderByHashes(hashes []string) []*tomox_state.Or
 
 	if err := sc.DB(db.dbName).C("orders").Find(query).All(&result); err != nil && err != mgo.ErrNotFound {
 		log.Error("failed to GetListOrderByHashes", "err", err, "hashes", hashes)
+		return []*tomox_state.OrderItem{}
 	}
 	return result
 }

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -239,10 +239,10 @@ func (db *MongoDatabase) InitBulk() *mgo.Session {
 
 func (db *MongoDatabase) CommitBulk(sc *mgo.Session) error {
 	defer sc.Close()
-	if _, err := db.orderBulk.Run(); err != nil {
+	if _, err := db.orderBulk.Run(); err != nil && !mgo.IsDup(err) {
 		return err
 	}
-	if _, err := db.tradeBulk.Run(); err != nil {
+	if _, err := db.tradeBulk.Run(); err != nil && !mgo.IsDup(err) {
 		return err
 	}
 	return nil

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -235,8 +235,6 @@ func (db *MongoDatabase) InitBulk() *mgo.Session {
 func (db *MongoDatabase) CommitBulk(sc *mgo.Session) error {
 	defer func() {
 		sc.Close()
-		db.orderBulk = sc.DB(db.dbName).C("orders").Bulk()
-		db.tradeBulk = sc.DB(db.dbName).C("trades").Bulk()
 	}()
 	if _, err := db.orderBulk.Run(); err != nil {
 		return err

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -220,8 +220,9 @@ func (db *MongoDatabase) CommitOrder(cacheKey string, o *tomox_state.OrderItem) 
 }
 
 func (db *MongoDatabase) CommitTrade(t *Trade) error {
-	query := bson.M{"hash": t.Hash.Hex()}
-	db.tradeBulk.Upsert(query, t)
+	// for trades: insert only, no update
+	// Hence, insert is better than upsert
+	db.tradeBulk.Insert(t)
 	return nil
 }
 

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -214,8 +214,12 @@ func (db *MongoDatabase) CommitOrder(cacheKey string, o *tomox_state.OrderItem) 
 	if len(o.Key) == 0 {
 		o.Key = cacheKey
 	}
-	query := bson.M{"hash": o.Hash.Hex()}
-	db.orderBulk.Upsert(query, o)
+	if o.Status == OrderStatusOpen {
+		db.orderBulk.Insert(o)
+	} else {
+		query := bson.M{"hash": o.Hash.Hex()}
+		db.orderBulk.Upsert(query, o)
+	}
 	return nil
 }
 

--- a/tomox/order_processor.go
+++ b/tomox/order_processor.go
@@ -1,7 +1,6 @@
 package tomox
 
 import (
-	"encoding/hex"
 	"math/big"
 	"strconv"
 	"time"
@@ -191,8 +190,8 @@ func processOrderList(statedb *state.StateDB, tomoXstatedb *tomox_state.TomoXSta
 		log.Debug("TRADE", "orderBook", orderBook.Hex(), "Price 1", price, "Price 2", order.Price, "Amount", tradedQuantity, "orderId", orderId, "side", side)
 
 		transactionRecord := make(map[string]string)
-		transactionRecord[TradeTakerOrderHash] = hex.EncodeToString(order.Hash.Bytes())
-		transactionRecord[TradeMakerOrderHash] = hex.EncodeToString(oldestOrder.Hash.Bytes())
+		transactionRecord[TradeTakerOrderHash] = order.Hash.Hex()
+		transactionRecord[TradeMakerOrderHash] = oldestOrder.Hash.Hex()
 		transactionRecord[TradeTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)
 		transactionRecord[TradeQuantity] = tradedQuantity.String()
 		transactionRecord[TradeMakerExchange] = oldestOrder.ExchangeAddress.String()

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -356,7 +356,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		// maker dirty order
 		makerFilledAmount := big.NewInt(0)
 		if amount, ok := makerDirtyFilledAmount[trade[TradeMakerOrderHash]]; ok {
-			makerFilledAmount = amount
+			makerFilledAmount = CloneBigInt(amount)
 		}
 		makerFilledAmount.Add(makerFilledAmount, filledAmount)
 		makerDirtyFilledAmount[trade[TradeMakerOrderHash]] = makerFilledAmount
@@ -364,9 +364,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 
 		//updatedTakerOrder = tomox.updateMatchedOrder(updatedTakerOrder, filledAmount, txMatchTime, txHash)
 		//  update filledAmount, status of takerOrder
-		updatedFillAmount := new(big.Int)
-		updatedFillAmount.Add(updatedTakerOrder.FilledAmount, filledAmount)
-		updatedTakerOrder.FilledAmount = updatedFillAmount
+		updatedTakerOrder.FilledAmount.Add(updatedTakerOrder.FilledAmount, filledAmount)
 		if updatedTakerOrder.FilledAmount.Cmp(updatedTakerOrder.Quantity) < 0 {
 			updatedTakerOrder.Status = OrderStatusPartialFilled
 		} else {
@@ -379,6 +377,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
 	}
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
+	log.Debug("GetListOrderByHashes", "len(makerDirtyHashes)", len(makerDirtyHashes), "len(makerOrders)", len(makerOrders))
 	for _, o := range makerOrders {
 		lastState = OrderHistoryItem{
 			TxHash:       o.TxHash,

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -374,6 +374,10 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 
 	}
+	log.Debug("PutObject processed takerOrder", "takerOrder", ToJSON(updatedTakerOrder))
+	if err := db.PutObject(updatedTakerOrder.Hash.Bytes(), updatedTakerOrder); err != nil {
+		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
+	}
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
 	for _, o := range makerOrders {
 		lastState = OrderHistoryItem{
@@ -394,10 +398,6 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		if err := db.PutObject(o.Hash.Bytes(), o); err != nil {
 			return fmt.Errorf("SDKNode: failed to put processed makerOrder. Hash: %s Error: %s", o.Hash.Hex(), err.Error())
 		}
-	}
-	log.Debug("PutObject processed takerOrder", "takerOrder", ToJSON(updatedTakerOrder))
-	if err := db.PutObject(updatedTakerOrder.Hash.Bytes(), updatedTakerOrder); err != nil {
-		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
 	}
 	if err := db.CommitBulk(sc); err != nil {
 		return fmt.Errorf("SDKNode fail to commit bulk update orders, trades at txhash %s . Error: %s", txHash.Hex(), err.Error())

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"time"
 
-	"encoding/hex"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/log"
@@ -262,48 +260,53 @@ func (tomox *TomoX) ProcessOrderPending(pending map[common.Address]types.OrderTr
 // 		b. Update status of regrading orders to sdktypes.OrderStatusFilled
 func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Hash, txMatchTime time.Time, statedb *state.StateDB) error {
 	var (
-		order *tomox_state.OrderItem
-		err   error
+		// originTakerOrder: order get from db, nil if it doesn't exist
+		// takerOrderInTx: order decoded from txdata
+		// updatedTakerOrder: order with new status, filledAmount, CreatedAt, UpdatedAt. This will be inserted to db
+		originTakerOrder, takerOrderInTx, updatedTakerOrder *tomox_state.OrderItem
+		makerDirtyHashes                                    []string
+		makerDirtyFilledAmount                              map[string]*big.Int
+		err                                                 error
 	)
 	db := tomox.GetMongoDB()
+	sc := db.InitBulk()
 
-	// 1. put processed order to db
-	if order, err = txDataMatch.DecodeOrder(); err != nil {
-		log.Error("SDK node decode order failed", "txDataMatch", txDataMatch)
-		return fmt.Errorf("SDK node decode order failed")
+	// 1. put processed takerOrderInTx to db
+	if takerOrderInTx, err = txDataMatch.DecodeOrder(); err != nil {
+		log.Error("SDK node decode takerOrderInTx failed", "txDataMatch", txDataMatch)
+		return fmt.Errorf("SDK node decode takerOrderInTx failed")
 	}
 	lastState := OrderHistoryItem{}
-	val, err := db.GetObject(order.Hash.Bytes(), &tomox_state.OrderItem{})
+	val, err := db.GetObject(takerOrderInTx.Hash.Bytes(), &tomox_state.OrderItem{})
 	if err == nil && val != nil {
-		originOrder := val.(*tomox_state.OrderItem)
+		originTakerOrder = val.(*tomox_state.OrderItem)
 		lastState = OrderHistoryItem{
-			TxHash:       originOrder.TxHash,
-			FilledAmount: CloneBigInt(originOrder.FilledAmount),
-			Status:       originOrder.Status,
+			TxHash:       originTakerOrder.TxHash,
+			FilledAmount: CloneBigInt(originTakerOrder.FilledAmount),
+			Status:       originTakerOrder.Status,
 		}
 	}
+	if originTakerOrder != nil {
+		updatedTakerOrder = originTakerOrder
+	} else {
+		updatedTakerOrder = takerOrderInTx
+	}
 
-	if order.Status != OrderStatusCancelled {
-		order.Status = OrderStatusOpen
+	if takerOrderInTx.Status != OrderStatusCancelled {
+		updatedTakerOrder.Status = OrderStatusOpen
 	}
-	order.TxHash = txHash
-	if order.CreatedAt.IsZero() {
-		order.CreatedAt = txMatchTime
+	updatedTakerOrder.TxHash = txHash
+	if updatedTakerOrder.CreatedAt.IsZero() {
+		updatedTakerOrder.CreatedAt = txMatchTime
 	}
-	order.UpdatedAt = txMatchTime
+	updatedTakerOrder.UpdatedAt = txMatchTime
 
-	tomox.UpdateOrderCache(order.PairName, order.OrderID, txHash, lastState)
+	tomox.UpdateOrderCache(updatedTakerOrder.PairName, updatedTakerOrder.OrderID, txHash, lastState)
 
-	log.Debug("PutObject processed order", "order", order)
-	if err := db.PutObject(order.Hash.Bytes(), order); err != nil {
-		return fmt.Errorf("SDKNode: failed to put processed order. Error: %s", err.Error())
-	}
-	if order.Status == OrderStatusCancelled {
-		return nil
-	}
 	// 2. put trades to db and update status to FILLED
 	trades := txDataMatch.GetTrades()
 	log.Debug("Got trades", "number", len(trades), "trades", trades)
+	makerDirtyFilledAmount = make(map[string]*big.Int)
 	for _, trade := range trades {
 		// 2.a. put to trades
 		tradeRecord := &Trade{}
@@ -314,23 +317,23 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 		tradeRecord.Amount = quantity
 		tradeRecord.PricePoint = price
-		tradeRecord.PairName = order.PairName
-		tradeRecord.BaseToken = order.BaseToken
-		tradeRecord.QuoteToken = order.QuoteToken
+		tradeRecord.PairName = updatedTakerOrder.PairName
+		tradeRecord.BaseToken = updatedTakerOrder.BaseToken
+		tradeRecord.QuoteToken = updatedTakerOrder.QuoteToken
 		tradeRecord.Status = TradeStatusSuccess
-		tradeRecord.Taker = order.UserAddress
+		tradeRecord.Taker = updatedTakerOrder.UserAddress
 		tradeRecord.Maker = common.HexToAddress(trade[TradeMaker])
-		tradeRecord.TakerOrderHash = order.Hash
+		tradeRecord.TakerOrderHash = updatedTakerOrder.Hash
 		tradeRecord.MakerOrderHash = common.HexToHash(trade[TradeMakerOrderHash])
 		tradeRecord.TxHash = txHash
-		tradeRecord.TakerOrderSide = order.Side
-		tradeRecord.TakerExchange = order.ExchangeAddress
+		tradeRecord.TakerOrderSide = updatedTakerOrder.Side
+		tradeRecord.TakerExchange = updatedTakerOrder.ExchangeAddress
 		tradeRecord.MakerExchange = common.HexToAddress(trade[TradeMakerExchange])
 
 		// feeAmount: all fees are calculated in quoteToken
 		quoteTokenQuantity := big.NewInt(0).Mul(quantity, price)
 		quoteTokenQuantity = big.NewInt(0).Div(quoteTokenQuantity, common.BasePrice)
-		takerFee := big.NewInt(0).Mul(quoteTokenQuantity, tomox_state.GetExRelayerFee(order.ExchangeAddress, statedb))
+		takerFee := big.NewInt(0).Mul(quoteTokenQuantity, tomox_state.GetExRelayerFee(updatedTakerOrder.ExchangeAddress, statedb))
 		takerFee = big.NewInt(0).Div(takerFee, common.TomoXBaseFee)
 		tradeRecord.TakeFee = takerFee
 
@@ -343,58 +346,62 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		tradeRecord.UpdatedAt = txMatchTime
 		tradeRecord.Hash = tradeRecord.ComputeHash()
 
-		// 2.b. update status and filledAmount
-		filledAmount := quantity
-		// update order status of relating orders
-		if err := tomox.updateMatchedOrder(trade[TradeMakerOrderHash], filledAmount, txMatchTime, txHash); err != nil {
-			return err
-		}
-		if err := tomox.updateMatchedOrder(trade[TradeTakerOrderHash], filledAmount, txMatchTime, txHash); err != nil {
-			return err
-		}
-
-		log.Debug("TRADE history", "order", order, "trade", tradeRecord)
+		log.Debug("TRADE history", "trade", tradeRecord)
 		if err := db.PutObject(EmptyKey(), tradeRecord); err != nil {
 			return fmt.Errorf("SDKNode: failed to store tradeRecord %s", err.Error())
 		}
-	}
-	return nil
-}
 
-func (tomox *TomoX) updateMatchedOrder(hashString string, filledAmount *big.Int, txMatchTime time.Time, txHash common.Hash) error {
-	log.Debug("updateMatchedOrder", "hash", hashString, "filledAmount", filledAmount)
-	db := tomox.GetMongoDB()
-	orderHashBytes, err := hex.DecodeString(hashString)
-	if err != nil {
-		return fmt.Errorf("SDKNode: failed to decode orderKey. Key: %s", hashString)
-	}
-	val, err := db.GetObject(orderHashBytes, &tomox_state.OrderItem{})
-	if err != nil || val == nil {
-		return fmt.Errorf("SDKNode: failed to get order. Key: %s", hashString)
-	}
-	matchedOrder := val.(*tomox_state.OrderItem)
+		// 2.b. update status and filledAmount
+		filledAmount := quantity
+		// maker dirty order
+		makerFilledAmount := big.NewInt(0)
+		if amount, ok := makerDirtyFilledAmount[trade[TradeMakerOrderHash]]; ok {
+			makerFilledAmount = amount
+		}
+		makerFilledAmount.Add(makerFilledAmount, filledAmount)
+		makerDirtyFilledAmount[trade[TradeMakerOrderHash]] = makerFilledAmount
+		makerDirtyHashes = append(makerDirtyHashes, trade[TradeMakerOrderHash])
 
-	lastState := OrderHistoryItem{
-		TxHash:       matchedOrder.TxHash,
-		FilledAmount: CloneBigInt(matchedOrder.FilledAmount),
-		Status:       matchedOrder.Status,
-	}
+		//updatedTakerOrder = tomox.updateMatchedOrder(updatedTakerOrder, filledAmount, txMatchTime, txHash)
+		//  update filledAmount, status of takerOrder
+		updatedFillAmount := new(big.Int)
+		updatedFillAmount.Add(updatedTakerOrder.FilledAmount, filledAmount)
+		updatedTakerOrder.FilledAmount = updatedFillAmount
+		if updatedTakerOrder.FilledAmount.Cmp(updatedTakerOrder.Quantity) < 0 {
+			updatedTakerOrder.Status = OrderStatusPartialFilled
+		} else {
+			updatedTakerOrder.Status = OrderStatusFilled
+		}
 
-	updatedFillAmount := new(big.Int)
-	updatedFillAmount.Add(matchedOrder.FilledAmount, filledAmount)
-	matchedOrder.FilledAmount = updatedFillAmount
-	if matchedOrder.FilledAmount.Cmp(matchedOrder.Quantity) < 0 {
-		matchedOrder.Status = OrderStatusPartialFilled
-	} else {
-		matchedOrder.Status = OrderStatusFilled
 	}
-	matchedOrder.UpdatedAt = txMatchTime
-	matchedOrder.TxHash = txHash
-
-	if err = db.PutObject(matchedOrder.Hash.Bytes(), matchedOrder); err != nil {
-		return fmt.Errorf("SDKNode: failed to update matchedOrder to sdkNode %s", err.Error())
+	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
+	for _, o := range makerOrders {
+		lastState = OrderHistoryItem{
+			TxHash:       o.TxHash,
+			FilledAmount: CloneBigInt(o.FilledAmount),
+			Status:       o.Status,
+		}
+		tomox.UpdateOrderCache(o.PairName, o.OrderID, txHash, lastState)
+		o.TxHash = txHash
+		o.UpdatedAt = txMatchTime
+		o.FilledAmount.Add(o.FilledAmount, makerDirtyFilledAmount[o.Hash.Hex()])
+		if o.FilledAmount.Cmp(o.Quantity) < 0 {
+			o.Status = OrderStatusPartialFilled
+		} else {
+			o.Status = OrderStatusFilled
+		}
+		log.Debug("PutObject processed makerOrder", "makerOrder", ToJSON(o))
+		if err := db.PutObject(o.Hash.Bytes(), o); err != nil {
+			return fmt.Errorf("SDKNode: failed to put processed makerOrder. Hash: %s Error: %s", o.Hash.Hex(), err.Error())
+		}
 	}
-	tomox.UpdateOrderCache(matchedOrder.PairName, matchedOrder.OrderID, txHash, lastState)
+	log.Debug("PutObject processed takerOrder", "takerOrder", ToJSON(updatedTakerOrder))
+	if err := db.PutObject(updatedTakerOrder.Hash.Bytes(), updatedTakerOrder); err != nil {
+		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
+	}
+	if err := db.CommitBulk(sc); err != nil {
+		return fmt.Errorf("SDKNode fail to commit bulk update orders, trades at txhash %s . Error: %s", txHash.Hex(), err.Error())
+	}
 	return nil
 }
 

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -377,7 +377,6 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
 	}
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
-	log.Debug("GetListOrderByHashes", "len(makerDirtyHashes)", len(makerDirtyHashes), "len(makerOrders)", len(makerOrders))
 	for _, o := range makerOrders {
 		lastState = OrderHistoryItem{
 			TxHash:       o.TxHash,

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -294,6 +294,8 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 
 	if takerOrderInTx.Status != OrderStatusCancelled {
 		updatedTakerOrder.Status = OrderStatusOpen
+	} else {
+		updatedTakerOrder.Status = OrderStatusCancelled
 	}
 	updatedTakerOrder.TxHash = txHash
 	if updatedTakerOrder.CreatedAt.IsZero() {


### PR DESCRIPTION
**Purpose:** 
       Improve process `logExchangeData` to mongodb in SDK full nodes


**Changes in this PR:**
- Insert `trades` instead of `upsert`
- Insert `open` orders, upsert `cancel` `partial_filled` `filled` orders
- Bulk update `orders`, `trades` ( Execute `OrderBulk` first )

**Note:** still keep `logExchangeData` in a synchronous process https://github.com/tomochain/tomochain/blob/tomoX/core/blockchain.go#L1450