### PR TITLE
locking while writing to chain

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -354,7 +354,9 @@ func (self *worker) wait() {
 			for _, log := range work.state.Logs() {
 				log.BlockHash = block.Hash()
 			}
+			self.currentMu.Lock()
 			stat, err := self.chain.WriteBlockWithState(block, work.receipts, work.state, work.tomoxState)
+			self.currentMu.Unlock()
 			if err != nil {
 				log.Error("Failed writing block to chain", "err", err)
 				continue


### PR DESCRIPTION
fatal error: concurrent map iteration and map write

goroutine 86064036 [running]:
runtime.throw(0x117f48f, 0x26)
        /usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc025d821e8 sp=0xc025d821b8 pc=0x443012
runtime.mapiternext(0xc025d82498)
        /usr/local/go/src/runtime/map.go:860 +0x597 fp=0xc025d82270 sp=0xc025d821e8 pc=0x4245a7
github.com/ethereum/go-ethereum/core/state.(*StateDB).Copy(0xc038a401e0, 0x0)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/state/statedb.go:485 +0x31e fp=0xc025d82508 sp=0xc025d82270 pc=0x73994e
github.com/ethereum/go-ethereum/miner.(*worker).pending(0xc023806780, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/miner/worker.go:206 +0x151 fp=0xc025d82580 sp=0xc025d82508 pc=0xbf5d31
github.com/ethereum/go-ethereum/miner.(*Miner).Pending(...)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/miner/miner.go:165
github.com/ethereum/go-ethereum/eth.(*EthApiBackend).StateAndHeaderByNumber(0xc023cd2220, 0x13b7fc0, 0xc021775fb0, 0xfffffffffffffffe, 0x219be20, 0x0, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/api_backend.go:100 +0x16d fp=0xc025d82608 sp=0xc025d82580 pc=0xc60c0d
github.com/ethereum/go-ethereum/internal/ethapi.(*PublicBlockChainAPI).doCall(0xc012926050, 0x13b7fc0, 0xc021775fb0, 0x0, 0x0, 0x0, 0xc003ae1440, 0x0, 0x0, 0x0, ...)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/internal/ethapi/api.go:1030 +0x145 fp=0xc025d850c8 sp=0xc025d82608 pc=0xc11425
github.com/ethereum/go-ethereum/internal/ethapi.(*PublicBlockChainAPI).Call(0xc012926050, 0x13b7fc0, 0xc021775fb0, 0x0, 0x0, 0x0, 0xc003ae1440, 0x0, 0x0, 0x0, ...)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/internal/ethapi/api.go:1094 +0xcc fp=0xc025d879d8 sp=0xc025d850c8 pc=0xc11e5c
runtime.call256(0xc00d862810, 0xc00a603d58, 0xc03cde4f70, 0xa0000000c8)
        /usr/local/go/src/runtime/asm_amd64.s:522 +0x55 fp=0xc025d87ae8 sp=0xc025d879d8 pc=0x470e65
reflect.Value.call(0xc02148a180, 0xc00a603d58, 0x13, 0x112cdd0, 0x4, 0xc012da3440, 0x4, 0x4, 0x4, 0xc012da3440, ...)
        /usr/local/go/src/reflect/value.go:447 +0x461 fp=0xc025d87d08 sp=0xc025d87ae8 pc=0x49f391
reflect.Value.Call(0xc02148a180, 0xc00a603d58, 0x13, 0xc012da3440, 0x4, 0x4, 0x2, 0x2, 0x11bfa38)
        /usr/local/go/src/reflect/value.go:308 +0xa4 fp=0xc025d87d70 sp=0xc025d87d08 pc=0x49ee14
github.com/ethereum/go-ethereum/rpc.(*Server).handle(0xc00f013e00, 0x13b7fc0, 0xc021775fb0, 0x13c40c0, 0xc032318690, 0xc012da3380, 0xc02044e738, 0x441d8f, 0xc000000008)
        /home/ubuntu/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/rpc/server.go:311 +0x6cf fp=0xc025d87ed8 sp=0xc025d87d70 pc=0x8e8daf
github.com/ethereum/go-ethereum/rpc.(*Server).exec(0xc00f013e00, 0x13b7fc0, 0xc021775fb0, 0x13c40c0, 0xc032318690, 0xc012da3380)
