### PR TITLE
Ignore orders in old blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2263,10 +2263,10 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 	}()
 	for _, txMatchBatch := range txMatchBatchData {
 		for _, txMatch := range txMatchBatch.Data {
-			// the smallest time unit in mongodb is microsecond
+			// the smallest time unit in mongodb is millisecond
 			// hence, we should update time in second
-			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to second here
-			txMatchTime := time.Unix(txMatchBatch.Timestamp / 1e9, 0).UTC()
+			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
+			txMatchTime := time.Unix(txMatchBatch.Timestamp / 1e6, 0).UTC()
 			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState); err != nil {
 				log.Error("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2263,7 +2263,10 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 	}()
 	for _, txMatchBatch := range txMatchBatchData {
 		for _, txMatch := range txMatchBatch.Data {
-			txMatchTime := time.Unix(0, txMatchBatch.Timestamp)
+			// the smallest time unit in mongodb is microsecond
+			// hence, we should update time in second
+			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to second here
+			txMatchTime := time.Unix(txMatchBatch.Timestamp / 1e9, 0).UTC()
 			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState); err != nil {
 				log.Error("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -3,11 +3,11 @@ package tomox
 import (
 	"encoding/json"
 	"errors"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/tomox/tomox_state"
 	"math/big"
 	"strconv"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type Comparator func(a, b []byte) int
@@ -269,8 +269,8 @@ func DecodeTxMatchesBatch(data []byte) (TxMatchBatch, error) {
 	return txMatchResult, nil
 }
 
-func GetOrderHistoryKey(pairName string, orderId uint64) common.Hash {
-	return common.StringToHash(pairName + strconv.FormatUint(orderId, 10))
+func GetOrderHistoryKey(baseToken, quoteToken common.Address, orderId uint64) common.Hash {
+	return crypto.Keccak256Hash(baseToken.Bytes(), quoteToken.Bytes(), []byte(strconv.FormatUint(orderId, 10)))
 }
 func (tx TxDataMatch) DecodeOrder() (*tomox_state.OrderItem, error) {
 	order := &tomox_state.OrderItem{}

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -309,6 +309,12 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	if updatedTakerOrder.CreatedAt.IsZero() {
 		updatedTakerOrder.CreatedAt = txMatchTime
 	}
+	if !txMatchTime.After(updatedTakerOrder.UpdatedAt) {
+		log.Debug("Ignore old orders/trades", "txHash", txHash.Hex(), "txTime", txMatchTime)
+		return nil
+	}
+	tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.OrderID, txHash, lastState)
+	updatedTakerOrder.UpdatedAt = txMatchTime
 
 	// 2. put trades to db and update status to FILLED
 	trades := txDataMatch.GetTrades()
@@ -380,21 +386,18 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 			updatedTakerOrder.Status = OrderStatusFilled
 		}
 	}
-	if txMatchTime.After(updatedTakerOrder.UpdatedAt) {
-		tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.OrderID, txHash, lastState)
-		updatedTakerOrder.UpdatedAt = txMatchTime
-		log.Debug("PutObject processed takerOrder",
-			"pairName", updatedTakerOrder.PairName, "userAddr", updatedTakerOrder.UserAddress.Hex(), "side", updatedTakerOrder.Side,
-			"price", updatedTakerOrder.Price, "quantity", updatedTakerOrder.Quantity, "filledAmount", updatedTakerOrder.FilledAmount, "status", updatedTakerOrder.Status,
-			"hash", updatedTakerOrder.Hash.Hex(), "txHash", updatedTakerOrder.TxHash.Hex())
-		if err := db.PutObject(updatedTakerOrder.Hash, updatedTakerOrder); err != nil {
-			return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
-		}
+
+	log.Debug("PutObject processed takerOrder",
+		"pairName", updatedTakerOrder.PairName, "userAddr", updatedTakerOrder.UserAddress.Hex(), "side", updatedTakerOrder.Side,
+		"price", updatedTakerOrder.Price, "quantity", updatedTakerOrder.Quantity, "filledAmount", updatedTakerOrder.FilledAmount, "status", updatedTakerOrder.Status,
+		"hash", updatedTakerOrder.Hash.Hex(), "txHash", updatedTakerOrder.TxHash.Hex())
+	if err := db.PutObject(updatedTakerOrder.Hash, updatedTakerOrder); err != nil {
+		return fmt.Errorf("SDKNode: failed to put processed takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
 	}
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
 	log.Debug("Maker dirty orders", "len", len(makerOrders), "txhash", txHash.Hex())
 	for _, o := range makerOrders {
-		if txMatchTime.Before(o.UpdatedAt) {
+		if !txMatchTime.After(o.UpdatedAt) {
 			continue
 		}
 		lastState = OrderHistoryItem{
@@ -446,7 +449,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 		dirtyRejectedOrders := db.GetListOrderByHashes(rejectedHashes)
 		for _, order := range dirtyRejectedOrders {
-			if txMatchTime.Before(order.UpdatedAt) {
+			if !txMatchTime.After(order.UpdatedAt) {
 				continue
 			}
 			// cache order history for handling reorg


### PR DESCRIPTION
Changes in this PR:
- txMatchTime stores to mongodb in millisecond instead of nanosecond (reason: minimum unit time in mongodb is millisecond)
- Ignore old orders: 
    `  if  ! txMatchTime.After(updatedTakerOrder.UpdatedAt)` : ignore
- Update orderHistoryItem key using `crypto.Keccak256Hash(baseToken, quoteToken, orderId) ` instead of `hashOf(pairName, orderId)`
- All times is in UTC