### PR TITLE
Ignore orders in old blocks (follow up)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2263,7 +2263,11 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 	}()
 	for _, txMatchBatch := range txMatchBatchData {
 		for _, txMatch := range txMatchBatch.Data {
-			txMatchTime := time.Unix(0, txMatchBatch.Timestamp)
+			// the smallest time unit in mongodb is millisecond
+			// hence, we should update time in millisecond
+			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
+			milliSecond := txMatchBatch.Timestamp / 1e6
+			txMatchTime := time.Unix(0, milliSecond * 1e6).UTC()
 			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState); err != nil {
 				log.Error("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2261,14 +2261,16 @@ func (bc *BlockChain) logExchangeData(block *types.Block) {
 		// That's why we should put this log statement in an anonymous function
 		log.Debug("logExchangeData takes", "time", common.PrettyDuration(time.Since(start)), "blockNumber", block.NumberU64())
 	}()
+
 	for _, txMatchBatch := range txMatchBatchData {
+		dirtyOrderCount := uint64(0)
 		for _, txMatch := range txMatchBatch.Data {
 			// the smallest time unit in mongodb is millisecond
 			// hence, we should update time in millisecond
 			// old txData has been attached with nanosecond, to avoid hard fork, convert nanosecond to millisecond here
 			milliSecond := txMatchBatch.Timestamp / 1e6
 			txMatchTime := time.Unix(0, milliSecond * 1e6).UTC()
-			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState); err != nil {
+			if err := tomoXService.SyncDataToSDKNode(txMatch, txMatchBatch.TxHash, txMatchTime, currentState, &dirtyOrderCount); err != nil {
 				log.Error("failed to SyncDataToSDKNode ", "blockNumber", block.Number(), "err", err)
 				return
 			}

--- a/tomox/batchdb.go
+++ b/tomox/batchdb.go
@@ -127,6 +127,6 @@ func (db *BatchDatabase) InitBulk() *mgo.Session {
 	return nil
 }
 
-func (db *BatchDatabase) CommitBulk(sc *mgo.Session) error {
+func (db *BatchDatabase) CommitBulk() error {
 	return nil
 }

--- a/tomox/common.go
+++ b/tomox/common.go
@@ -3,11 +3,11 @@ package tomox
 import (
 	"encoding/json"
 	"errors"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/tomox/tomox_state"
 	"math/big"
 	"strconv"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type Comparator func(a, b []byte) int
@@ -269,8 +269,8 @@ func DecodeTxMatchesBatch(data []byte) (TxMatchBatch, error) {
 	return txMatchResult, nil
 }
 
-func GetOrderHistoryKey(pairName string, orderId uint64) common.Hash {
-	return common.StringToHash(pairName + strconv.FormatUint(orderId, 10))
+func GetOrderHistoryKey(baseToken, quoteToken common.Address, orderId uint64) common.Hash {
+	return crypto.Keccak256Hash(baseToken.Bytes(), quoteToken.Bytes(), []byte(strconv.FormatUint(orderId, 10)))
 }
 func (tx TxDataMatch) DecodeOrder() (*tomox_state.OrderItem, error) {
 	order := &tomox_state.OrderItem{}

--- a/tomox/interfaces.go
+++ b/tomox/interfaces.go
@@ -21,7 +21,7 @@ type OrderDao interface {
 	GetListOrderByHashes(hashes []string) []*tomox_state.OrderItem
 	DeleteTradeByTxHash(txhash common.Hash)
 	InitBulk() *mgo.Session
-	CommitBulk(sc *mgo.Session) error
+	CommitBulk() error
 
 	// leveldb methods
 	Put(key []byte, value []byte) error

--- a/tomox/mongodb.go
+++ b/tomox/mongodb.go
@@ -233,8 +233,7 @@ func (db *MongoDatabase) InitBulk() *mgo.Session {
 	return sc
 }
 
-func (db *MongoDatabase) CommitBulk(sc *mgo.Session) error {
-	defer sc.Close()
+func (db *MongoDatabase) CommitBulk() error {
 	if _, err := db.orderBulk.Run(); err != nil && !mgo.IsDup(err) {
 		return err
 	}

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -309,9 +309,12 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	if updatedTakerOrder.CreatedAt.IsZero() {
 		updatedTakerOrder.CreatedAt = txMatchTime
 	}
+	if !txMatchTime.After(updatedTakerOrder.UpdatedAt) {
+		log.Debug("Ignore old orders/trades", "txHash", txHash.Hex(), "txTime", txMatchTime)
+		return nil
+	}
+	tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.OrderID, txHash, lastState)
 	updatedTakerOrder.UpdatedAt = txMatchTime
-
-	tomox.UpdateOrderCache(updatedTakerOrder.PairName, updatedTakerOrder.OrderID, txHash, lastState)
 
 	// 2. put trades to db and update status to FILLED
 	trades := txDataMatch.GetTrades()
@@ -394,12 +397,15 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
 	log.Debug("Maker dirty orders", "len", len(makerOrders), "txhash", txHash.Hex())
 	for _, o := range makerOrders {
+		if !txMatchTime.After(o.UpdatedAt) {
+			continue
+		}
 		lastState = OrderHistoryItem{
 			TxHash:       o.TxHash,
 			FilledAmount: CloneBigInt(o.FilledAmount),
 			Status:       o.Status,
 		}
-		tomox.UpdateOrderCache(o.PairName, o.OrderID, txHash, lastState)
+		tomox.UpdateOrderCache(o.BaseToken, o.QuoteToken, o.OrderID, txHash, lastState)
 		o.TxHash = txHash
 		o.UpdatedAt = txMatchTime
 		o.FilledAmount.Add(o.FilledAmount, makerDirtyFilledAmount[o.Hash.Hex()])
@@ -426,7 +432,15 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		// updateRejectedOrders
 		for _, rejectedOrder := range rejectedOrders {
 			rejectedHashes = append(rejectedHashes, rejectedOrder.Hash.Hex())
-			if updatedTakerOrder.Hash == rejectedOrder.Hash {
+			if updatedTakerOrder.Hash == rejectedOrder.Hash && txMatchTime.After(updatedTakerOrder.UpdatedAt) {
+				// cache order history for handling reorg
+				orderHistoryRecord := OrderHistoryItem{
+					TxHash:       updatedTakerOrder.TxHash,
+					FilledAmount: CloneBigInt(updatedTakerOrder.FilledAmount),
+					Status:       updatedTakerOrder.Status,
+				}
+				tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.OrderID, txHash, orderHistoryRecord)
+
 				updatedTakerOrder.Status = OrderStatusRejected
 				if err := db.PutObject(updatedTakerOrder.Hash, updatedTakerOrder); err != nil {
 					return fmt.Errorf("SDKNode: failed to reject takerOrder. Hash: %s Error: %s", updatedTakerOrder.Hash.Hex(), err.Error())
@@ -435,13 +449,16 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 		dirtyRejectedOrders := db.GetListOrderByHashes(rejectedHashes)
 		for _, order := range dirtyRejectedOrders {
+			if !txMatchTime.After(order.UpdatedAt) {
+				continue
+			}
 			// cache order history for handling reorg
 			orderHistoryRecord := OrderHistoryItem{
 				TxHash:       order.TxHash,
 				FilledAmount: CloneBigInt(order.FilledAmount),
 				Status:       order.Status,
 			}
-			tomox.UpdateOrderCache(order.PairName, order.OrderID, txHash, orderHistoryRecord)
+			tomox.UpdateOrderCache(order.BaseToken, order.QuoteToken, order.OrderID, txHash, orderHistoryRecord)
 
 			order.Status = OrderStatusRejected
 			if err = db.PutObject(order.Hash, order); err != nil {
@@ -478,7 +495,7 @@ func (tomox *TomoX) GetTomoxStateRoot(block *types.Block) (common.Hash, error) {
 	return tomox_state.EmptyRoot, nil
 }
 
-func (tomox *TomoX) UpdateOrderCache(pair string, orderId uint64, txhash common.Hash, lastState OrderHistoryItem) {
+func (tomox *TomoX) UpdateOrderCache(baseToken, quoteToken common.Address, orderId uint64, txhash common.Hash, lastState OrderHistoryItem) {
 	var orderCacheAtTxHash map[common.Hash]OrderHistoryItem
 	c, ok := tomox.orderCache.Get(txhash)
 	if !ok || c == nil {
@@ -486,7 +503,7 @@ func (tomox *TomoX) UpdateOrderCache(pair string, orderId uint64, txhash common.
 	} else {
 		orderCacheAtTxHash = c.(map[common.Hash]OrderHistoryItem)
 	}
-	orderKey := GetOrderHistoryKey(pair, orderId)
+	orderKey := GetOrderHistoryKey(baseToken, quoteToken, orderId)
 	_, ok = orderCacheAtTxHash[orderKey]
 	if !ok {
 		orderCacheAtTxHash[orderKey] = lastState
@@ -507,7 +524,7 @@ func (tomox *TomoX) RollbackReorgTxMatch(txhash common.Hash) {
 			continue
 		}
 		orderCacheAtTxHash := c.(map[common.Hash]OrderHistoryItem)
-		orderHistoryItem, _ := orderCacheAtTxHash[GetOrderHistoryKey(order.PairName, order.OrderID)]
+		orderHistoryItem, _ := orderCacheAtTxHash[GetOrderHistoryKey(order.BaseToken, order.QuoteToken, order.OrderID)]
 		if (orderHistoryItem == OrderHistoryItem{}) {
 			log.Debug("Tomox reorg: remove order due to empty orderHistory", "order", ToJSON(order))
 			if err := db.DeleteObject(order.Hash); err != nil {

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -266,7 +266,7 @@ func (tomox *TomoX) ProcessOrderPending(coinbase common.Address, ipcEndpoint str
 // 2. txMatchData.Trades: includes information of matched orders.
 // 		a. PutObject them to `trades` collection
 // 		b. Update status of regrading orders to sdktypes.OrderStatusFilled
-func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Hash, txMatchTime time.Time, statedb *state.StateDB) error {
+func (tomox *TomoX)  SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Hash, txMatchTime time.Time, statedb *state.StateDB, dirtyOrderCount *uint64) error {
 	var (
 		// originTakerOrder: order get from db, nil if it doesn't exist
 		// takerOrderInTx: order decoded from txdata
@@ -309,10 +309,12 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	if updatedTakerOrder.CreatedAt.IsZero() {
 		updatedTakerOrder.CreatedAt = txMatchTime
 	}
-	if !txMatchTime.After(updatedTakerOrder.UpdatedAt) {
-		log.Debug("Ignore old orders/trades", "txHash", txHash.Hex(), "txTime", txMatchTime)
+	if txMatchTime.Before(updatedTakerOrder.UpdatedAt) || (txMatchTime.Equal(updatedTakerOrder.UpdatedAt) && *dirtyOrderCount == 0) {
+		log.Debug("Ignore old orders/trades taker", "txHash", txHash.Hex(), "txTime", txMatchTime.UnixNano(), "updatedAt", updatedTakerOrder.UpdatedAt.UnixNano())
 		return nil
 	}
+	*dirtyOrderCount++
+
 	tomox.UpdateOrderCache(updatedTakerOrder.BaseToken, updatedTakerOrder.QuoteToken, updatedTakerOrder.OrderID, txHash, lastState)
 	updatedTakerOrder.UpdatedAt = txMatchTime
 
@@ -397,7 +399,8 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	makerOrders := db.GetListOrderByHashes(makerDirtyHashes)
 	log.Debug("Maker dirty orders", "len", len(makerOrders), "txhash", txHash.Hex())
 	for _, o := range makerOrders {
-		if !txMatchTime.After(o.UpdatedAt) {
+		if txMatchTime.Before(o.UpdatedAt) {
+			log.Debug("Ignore old orders/trades maker", "txHash", txHash.Hex(), "txTime", txMatchTime.UnixNano(), "updatedAt", updatedTakerOrder.UpdatedAt.UnixNano())
 			continue
 		}
 		lastState = OrderHistoryItem{
@@ -432,7 +435,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		// updateRejectedOrders
 		for _, rejectedOrder := range rejectedOrders {
 			rejectedHashes = append(rejectedHashes, rejectedOrder.Hash.Hex())
-			if updatedTakerOrder.Hash == rejectedOrder.Hash && txMatchTime.After(updatedTakerOrder.UpdatedAt) {
+			if updatedTakerOrder.Hash == rejectedOrder.Hash && !txMatchTime.Before(updatedTakerOrder.UpdatedAt) {
 				// cache order history for handling reorg
 				orderHistoryRecord := OrderHistoryItem{
 					TxHash:       updatedTakerOrder.TxHash,
@@ -449,7 +452,8 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 		dirtyRejectedOrders := db.GetListOrderByHashes(rejectedHashes)
 		for _, order := range dirtyRejectedOrders {
-			if !txMatchTime.After(order.UpdatedAt) {
+			if txMatchTime.Before(order.UpdatedAt) {
+				log.Debug("Ignore old orders/trades reject", "txHash", txHash.Hex(), "txTime", txMatchTime.UnixNano(), "updatedAt", updatedTakerOrder.UpdatedAt.UnixNano())
 				continue
 			}
 			// cache order history for handling reorg

--- a/tomox/tomox.go
+++ b/tomox/tomox.go
@@ -278,7 +278,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 	)
 	db := tomox.GetMongoDB()
 	sc := db.InitBulk()
-
+	defer sc.Close()
 	// 1. put processed takerOrderInTx to db
 	if takerOrderInTx, err = txDataMatch.DecodeOrder(); err != nil {
 		log.Error("SDK node decode takerOrderInTx failed", "txDataMatch", txDataMatch)
@@ -467,7 +467,7 @@ func (tomox *TomoX) SyncDataToSDKNode(txDataMatch TxDataMatch, txHash common.Has
 		}
 	}
 
-	if err := db.CommitBulk(sc); err != nil {
+	if err := db.CommitBulk(); err != nil {
 		return fmt.Errorf("SDKNode fail to commit bulk update orders, trades at txhash %s . Error: %s", txHash.Hex(), err.Error())
 	}
 	return nil


### PR DESCRIPTION
The wrong approach of #806 is: `ignore txMatch if txMatchTime <= order.updatedAt`
The fact that: many orders, one order can be processed multiple times in the same tx (same txMatchTime)
So this PR 
- Updates that solution `ignore txMatch if txMatchTime < order.updatedAt`
- Another change: close mongodb connection in case of error https://github.com/tomochain/tomochain/commit/e167819e90b677fb4a2253137c89772901a2ae57